### PR TITLE
chain.TraverserFactory

### DIFF
--- a/job-runner/chain/chain.go
+++ b/job-runner/chain/chain.go
@@ -220,7 +220,7 @@ func (c *chain) Validate() error {
 }
 
 // RequestId returns the request id of the job chain.
-func (c *chain) RequestId() uint {
+func (c *chain) RequestId() string {
 	return c.JobChain.RequestId
 }
 

--- a/job-runner/chain/memory_repo.go
+++ b/job-runner/chain/memory_repo.go
@@ -3,8 +3,6 @@
 package chain
 
 import (
-	"strconv"
-
 	"github.com/square/spincycle/job-runner/kv"
 )
 
@@ -19,8 +17,8 @@ func NewMemoryRepo() *memoryRepo {
 	}
 }
 
-func (m *memoryRepo) Get(id uint) (*chain, error) {
-	val, err := m.Store.Get(uintToStr(id))
+func (m *memoryRepo) Get(id string) (*chain, error) {
+	val, err := m.Store.Get(id)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +32,7 @@ func (m *memoryRepo) Get(id uint) (*chain, error) {
 }
 
 func (m *memoryRepo) Add(chain *chain) error {
-	err := m.Store.Add(uintToStr(chain.RequestId()), chain)
+	err := m.Store.Add(chain.RequestId(), chain)
 	if err != nil {
 		return err
 	}
@@ -42,17 +40,11 @@ func (m *memoryRepo) Add(chain *chain) error {
 }
 
 func (m *memoryRepo) Set(chain *chain) error {
-	m.Store.Set(uintToStr(chain.RequestId()), chain)
+	m.Store.Set(chain.RequestId(), chain)
 	return nil
 }
 
-func (m *memoryRepo) Remove(id uint) error {
-	m.Store.Delete(uintToStr(id))
+func (m *memoryRepo) Remove(id string) error {
+	m.Store.Delete(id)
 	return nil
-}
-
-// ------------------------------------------------------------------------- //
-
-func uintToStr(id uint) string {
-	return strconv.FormatUint(uint64(id), 10)
 }

--- a/job-runner/chain/redis_repo.go
+++ b/job-runner/chain/redis_repo.go
@@ -97,7 +97,7 @@ func (r *RedisRepo) Set(chain *chain) error {
 }
 
 // Get takes a Chain RequestId and retrieves that Chain from redis.
-func (r *RedisRepo) Get(id uint) (*chain, error) {
+func (r *RedisRepo) Get(id string) (*chain, error) {
 	conn := r.ConnectionPool.Get()
 	defer conn.Close()
 
@@ -119,7 +119,7 @@ func (r *RedisRepo) Get(id uint) (*chain, error) {
 }
 
 // Remove takes a Chain RequestId and deletes that Chain from redis.
-func (r *RedisRepo) Remove(id uint) error {
+func (r *RedisRepo) Remove(id string) error {
 	conn := r.ConnectionPool.Get()
 	defer conn.Close()
 
@@ -151,7 +151,7 @@ func (r *RedisRepo) ping() error {
 
 // fmtIdKey takes a Chain RequestId and returns the key where that Chain is
 // stored in redis.
-func (r *RedisRepo) fmtIdKey(id uint) string {
+func (r *RedisRepo) fmtIdKey(id string) string {
 	return fmt.Sprintf("%s::%s::%d", r.Conf.Prefix, CHAIN_KEY, id)
 }
 

--- a/job-runner/chain/redis_repo_test.go
+++ b/job-runner/chain/redis_repo_test.go
@@ -42,7 +42,7 @@ func initRedis() (*miniredis.Miniredis, *chain.RedisRepo) {
 
 func initJc() *proto.JobChain {
 	return &proto.JobChain{
-		RequestId: 1,
+		RequestId: "abc",
 		AdjacencyList: map[string][]string{
 			"job1": []string{"job2", "job3"},
 		},

--- a/job-runner/chain/repo.go
+++ b/job-runner/chain/repo.go
@@ -17,8 +17,8 @@ var (
 
 // Repo stores and provides thread-safe access to job chains.
 type Repo interface {
-	Get(uint) (*chain, error)
+	Get(string) (*chain, error)
 	Add(*chain) error
 	Set(*chain) error
-	Remove(uint) error
+	Remove(string) error
 }

--- a/job-runner/chain/traverser.go
+++ b/job-runner/chain/traverser.go
@@ -81,7 +81,8 @@ func (f *traverserFactory) Make(jobChain proto.JobChain) (Traverser, error) {
 	// for the chain: running, cleaning up, removing from repo when done, etc.
 	// And traverser and chain have the same lifespan: traverser is done when
 	// chain is done.
-	return NewTraverser(chain, f.chainRepo, f.runnerFactory, f.runnerRepo)
+	tr := NewTraverser(chain, f.chainRepo, f.runnerFactory, f.runnerRepo)
+	return tr, nil
 }
 
 // A traverser represents a job chain and everything needed to traverse it.
@@ -109,7 +110,7 @@ type traverser struct {
 }
 
 // NewTraverser creates a new traverser for a job chain.
-func NewTraverser(chain *chain, cr Repo, rf runner.Factory, rr runner.Repo) (*traverser, error) {
+func NewTraverser(chain *chain, cr Repo, rf runner.Factory, rr runner.Repo) *traverser {
 	return &traverser{
 		chain:         chain,
 		chainRepo:     cr,
@@ -118,7 +119,7 @@ func NewTraverser(chain *chain, cr Repo, rf runner.Factory, rr runner.Repo) (*tr
 		stopChan:      make(chan struct{}),
 		runJobChan:    make(chan proto.Job),
 		doneJobChan:   make(chan proto.Job),
-	}, nil
+	}
 }
 
 // Run runs all jobs in the chain and blocks until all jobs complete or a job fails.

--- a/job-runner/chain/traverser_test.go
+++ b/job-runner/chain/traverser_test.go
@@ -61,12 +61,9 @@ func TestRunComplete(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(c, chainRepo, rf, rr)
-	if err != nil {
-		t.Fatalf("err = %s, expected nil", err)
-	}
+	traverser := NewTraverser(c, chainRepo, rf, rr)
 
-	err = traverser.Run()
+	err := traverser.Run()
 	if err != nil {
 		t.Errorf("err = %s, expected nil", err)
 	}
@@ -96,12 +93,9 @@ func TestRunNotComplete(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(c, chainRepo, rf, rr)
-	if err != nil {
-		t.Fatalf("err = %s, expected nil", err)
-	}
+	traverser := NewTraverser(c, chainRepo, rf, rr)
 
-	err = traverser.Run()
+	err := traverser.Run()
 	if err != nil {
 		t.Errorf("err = %s, expected nil", err)
 	}
@@ -137,12 +131,9 @@ func TestJobUnknownState(t *testing.T) {
 	for _, job := range c.JobChain.Jobs {
 		job.State = proto.STATE_UNKNOWN
 	}
-	traverser, err := NewTraverser(c, chainRepo, rf, rr)
-	if err != nil {
-		t.Fatalf("err = %s, expected nil", err)
-	}
+	traverser := NewTraverser(c, chainRepo, rf, rr)
 
-	if err = traverser.Run(); err != nil {
+	if err := traverser.Run(); err != nil {
 		t.Errorf("err = %s, expected nil", err)
 	}
 	if c.JobChain.State != proto.STATE_COMPLETE {
@@ -171,13 +162,11 @@ func TestJobData(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(c, chainRepo, rf, rr)
-	if err != nil {
-		t.Fatalf("err = %s, expected nil", err)
-	}
+	traverser := NewTraverser(c, chainRepo, rf, rr)
+
 	expectedJobData := map[string]interface{}{"k1": "v9", "k2": "v2"}
 
-	err = traverser.Run()
+	err := traverser.Run()
 	if err != nil {
 		t.Errorf("err = %s, expected nil", err)
 	}
@@ -210,10 +199,7 @@ func TestStop(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(c, chainRepo, rf, rr)
-	if err != nil {
-		t.Fatalf("err = %s, expected nil", err)
-	}
+	traverser := NewTraverser(c, chainRepo, rf, rr)
 	traverser.stopChan = stopChan
 
 	// Start the traverser.
@@ -267,10 +253,7 @@ func TestStopRepoError(t *testing.T) {
 	runnerRepo.Store = &mock.KVStore{
 		GetAllResp: map[string]interface{}{"not a": "runner"},
 	}
-	traverser, err := NewTraverser(c, chainRepo, rf, runnerRepo)
-	if err != nil {
-		t.Fatalf("err = %s, expected nil", err)
-	}
+	traverser := NewTraverser(c, chainRepo, rf, runnerRepo)
 	traverser.stopChan = stopChan
 
 	// Start the traverser.
@@ -283,7 +266,7 @@ func TestStopRepoError(t *testing.T) {
 		}
 	}
 
-	err = traverser.Stop()
+	err := traverser.Stop()
 
 	if err == nil {
 		t.Errorf("err = nil, expected %s", runner.ErrInvalidRunner)
@@ -312,10 +295,7 @@ func TestStatus(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(c, chainRepo, rf, rr)
-	if err != nil {
-		t.Fatalf("err = %s, expected nil", err)
-	}
+	traverser := NewTraverser(c, chainRepo, rf, rr)
 
 	// Start the traverser.
 	doneChan := make(chan struct{})
@@ -371,10 +351,7 @@ func TestRunJobsRunnerError(t *testing.T) {
 		Jobs: mock.InitJobs(1),
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(c, chainRepo, rf, rr)
-	if err != nil {
-		t.Fatalf("err = %s, expected nil", err)
-	}
+	traverser := NewTraverser(c, chainRepo, rf, rr)
 
 	// Start consuming from the runJobChan
 	go traverser.runJobs()
@@ -406,10 +383,7 @@ func TestRunJobsRepoAddError(t *testing.T) {
 	runnerRepo.Store = &mock.KVStore{
 		AddErr: mock.ErrKVStore,
 	}
-	traverser, err := NewTraverser(c, chainRepo, rf, runnerRepo)
-	if err != nil {
-		t.Fatalf("err = %s, expected nil", err)
-	}
+	traverser := NewTraverser(c, chainRepo, rf, runnerRepo)
 
 	// Start consuming from the runJobChan
 	go traverser.runJobs()

--- a/job-runner/chain/traverser_test.go
+++ b/job-runner/chain/traverser_test.go
@@ -24,14 +24,19 @@ func TestRunErrorNoFirstJob(t *testing.T) {
 		},
 	}
 	rr := runner.NewRepo()
-	jc := &proto.JobChain{
+	f := NewTraverserFactory(chainRepo, rf, rr)
+
+	jc := proto.JobChain{
+		RequestId:     "abc",
 		Jobs:          mock.InitJobs(2),
 		AdjacencyList: map[string][]string{},
 	}
-	c := NewChain(jc)
-	_, err := NewTraverser(chainRepo, rf, rr, c)
+	tr, err := f.Make(jc)
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
+	}
+	if tr != nil {
+		t.Errorf("got non-nil Traverser, expected nil on error")
 	}
 }
 
@@ -56,7 +61,7 @@ func TestRunComplete(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(chainRepo, rf, rr, c)
+	traverser, err := NewTraverser(c, chainRepo, rf, rr)
 	if err != nil {
 		t.Fatalf("err = %s, expected nil", err)
 	}
@@ -91,7 +96,7 @@ func TestRunNotComplete(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(chainRepo, rf, rr, c)
+	traverser, err := NewTraverser(c, chainRepo, rf, rr)
 	if err != nil {
 		t.Fatalf("err = %s, expected nil", err)
 	}
@@ -132,7 +137,7 @@ func TestJobUnknownState(t *testing.T) {
 	for _, job := range c.JobChain.Jobs {
 		job.State = proto.STATE_UNKNOWN
 	}
-	traverser, err := NewTraverser(chainRepo, rf, rr, c)
+	traverser, err := NewTraverser(c, chainRepo, rf, rr)
 	if err != nil {
 		t.Fatalf("err = %s, expected nil", err)
 	}
@@ -166,7 +171,7 @@ func TestJobData(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(chainRepo, rf, rr, c)
+	traverser, err := NewTraverser(c, chainRepo, rf, rr)
 	if err != nil {
 		t.Fatalf("err = %s, expected nil", err)
 	}
@@ -205,7 +210,7 @@ func TestStop(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(chainRepo, rf, rr, c)
+	traverser, err := NewTraverser(c, chainRepo, rf, rr)
 	if err != nil {
 		t.Fatalf("err = %s, expected nil", err)
 	}
@@ -262,7 +267,7 @@ func TestStopRepoError(t *testing.T) {
 	runnerRepo.Store = &mock.KVStore{
 		GetAllResp: map[string]interface{}{"not a": "runner"},
 	}
-	traverser, err := NewTraverser(chainRepo, rf, runnerRepo, c)
+	traverser, err := NewTraverser(c, chainRepo, rf, runnerRepo)
 	if err != nil {
 		t.Fatalf("err = %s, expected nil", err)
 	}
@@ -307,7 +312,7 @@ func TestStatus(t *testing.T) {
 		},
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(chainRepo, rf, rr, c)
+	traverser, err := NewTraverser(c, chainRepo, rf, rr)
 	if err != nil {
 		t.Fatalf("err = %s, expected nil", err)
 	}
@@ -366,7 +371,7 @@ func TestRunJobsRunnerError(t *testing.T) {
 		Jobs: mock.InitJobs(1),
 	}
 	c := NewChain(jc)
-	traverser, err := NewTraverser(chainRepo, rf, rr, c)
+	traverser, err := NewTraverser(c, chainRepo, rf, rr)
 	if err != nil {
 		t.Fatalf("err = %s, expected nil", err)
 	}
@@ -401,7 +406,7 @@ func TestRunJobsRepoAddError(t *testing.T) {
 	runnerRepo.Store = &mock.KVStore{
 		AddErr: mock.ErrKVStore,
 	}
-	traverser, err := NewTraverser(chainRepo, rf, runnerRepo, c)
+	traverser, err := NewTraverser(c, chainRepo, rf, runnerRepo)
 	if err != nil {
 		t.Fatalf("err = %s, expected nil", err)
 	}

--- a/job-runner/client/http.go
+++ b/job-runner/client/http.go
@@ -1,3 +1,5 @@
+// Copyright 2017, Square, Inc.
+
 // Package client provides an HTTP client for interacting with the Job Runner (JR) API.
 package client
 
@@ -16,11 +18,11 @@ type JRClient interface {
 	// NewJobChain takes a job chain and sends it to the JR.
 	NewJobChain(proto.JobChain) error
 	// StartRequest starts the job chain that corresponds to a given request Id.
-	StartRequest(uint) error
+	StartRequest(string) error
 	// StopRequest stops the job chain that corresponds to a given request Id.
-	StopRequest(uint) error
+	StopRequest(string) error
 	// RequestStatus gets the status of the job chain that corresponds to a given request Id.
-	RequestStatus(uint) (*proto.JobChainStatus, error)
+	RequestStatus(string) (*proto.JobChainStatus, error)
 }
 
 type jrClient struct {
@@ -60,9 +62,9 @@ func (c *jrClient) NewJobChain(jobChain proto.JobChain) error {
 	return nil
 }
 
-func (c *jrClient) StartRequest(requestId uint) error {
+func (c *jrClient) StartRequest(requestId string) error {
 	// PUT /api/v1/job-chains/${requestId}/start
-	url := fmt.Sprintf(c.baseUrl+"/api/v1/job-chains/%d/start", requestId)
+	url := fmt.Sprintf(c.baseUrl+"/api/v1/job-chains/%s/start", requestId)
 
 	// Make the request.
 	resp, body, err := c.put(url)
@@ -78,9 +80,9 @@ func (c *jrClient) StartRequest(requestId uint) error {
 	return nil
 }
 
-func (c *jrClient) StopRequest(requestId uint) error {
+func (c *jrClient) StopRequest(requestId string) error {
 	// PUT /api/v1/job-chains/${requestId}/stop
-	url := fmt.Sprintf(c.baseUrl+"/api/v1/job-chains/%d/stop", requestId)
+	url := fmt.Sprintf(c.baseUrl+"/api/v1/job-chains/%s/stop", requestId)
 
 	// Make the request.
 	resp, body, err := c.put(url)
@@ -95,9 +97,9 @@ func (c *jrClient) StopRequest(requestId uint) error {
 	return nil
 }
 
-func (c *jrClient) RequestStatus(requestId uint) (*proto.JobChainStatus, error) {
+func (c *jrClient) RequestStatus(requestId string) (*proto.JobChainStatus, error) {
 	// GET /api/v1/job-chains/${requestId}/status
-	url := fmt.Sprintf(c.baseUrl+"/api/v1/job-chains/%d/status", requestId)
+	url := fmt.Sprintf(c.baseUrl+"/api/v1/job-chains/%s/status", requestId)
 
 	// Make the request.
 	resp, body, err := c.get(url)

--- a/job-runner/client/http_test.go
+++ b/job-runner/client/http_test.go
@@ -20,7 +20,7 @@ func TestStartRequest(t *testing.T) {
 	}))
 	c := client.NewJRClient(&http.Client{}, ts.URL)
 
-	err := c.StartRequest(3)
+	err := c.StartRequest("1")
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
 	}
@@ -36,13 +36,13 @@ func TestStartRequest(t *testing.T) {
 	}))
 	c = client.NewJRClient(&http.Client{}, ts.URL)
 
-	err = c.StartRequest(3)
+	err = c.StartRequest("1")
 	if err != nil {
 		t.Errorf("err = %s, expected nil", err)
 	}
 	ts.Close()
 
-	expectedPath := "/api/v1/job-chains/3/start"
+	expectedPath := "/api/v1/job-chains/1/start"
 	if path != expectedPath {
 		t.Errorf("url path = %s, expected %s", path, expectedPath)
 	}
@@ -59,7 +59,7 @@ func TestStopRequest(t *testing.T) {
 	}))
 	c := client.NewJRClient(&http.Client{}, ts.URL)
 
-	err := c.StopRequest(3)
+	err := c.StopRequest("2")
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
 	}
@@ -75,13 +75,13 @@ func TestStopRequest(t *testing.T) {
 	}))
 	c = client.NewJRClient(&http.Client{}, ts.URL)
 
-	err = c.StopRequest(3)
+	err = c.StopRequest("2")
 	if err != nil {
 		t.Errorf("err = %s, expected nil", err)
 	}
 	ts.Close()
 
-	expectedPath := "/api/v1/job-chains/3/stop"
+	expectedPath := "/api/v1/job-chains/2/stop"
 	if path != expectedPath {
 		t.Errorf("url path = %s, expected %s", path, expectedPath)
 	}
@@ -98,7 +98,7 @@ func TestRequestStatus(t *testing.T) {
 	}))
 	c := client.NewJRClient(&http.Client{}, ts.URL)
 
-	_, err := c.RequestStatus(3)
+	_, err := c.RequestStatus("3")
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
 	}
@@ -112,7 +112,7 @@ func TestRequestStatus(t *testing.T) {
 	}))
 	c = client.NewJRClient(&http.Client{}, ts.URL)
 
-	_, err = c.RequestStatus(3)
+	_, err = c.RequestStatus("3")
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
 	}
@@ -126,11 +126,11 @@ func TestRequestStatus(t *testing.T) {
 		method = r.Method
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "{\"requestId\":3,\"jobStatuses\":[{\"name\":\"job1\",\"status\":\"job is running...\",\"state\":5}]}")
+		fmt.Fprintln(w, "{\"requestId\":\"3\",\"jobStatuses\":[{\"name\":\"job1\",\"status\":\"job is running...\",\"state\":5}]}")
 	}))
 	c = client.NewJRClient(&http.Client{}, ts.URL)
 
-	status, err := c.RequestStatus(3)
+	status, err := c.RequestStatus("3")
 	if err != nil {
 		t.Errorf("err = %s, expected nil", err)
 	}
@@ -153,7 +153,7 @@ func TestRequestStatus(t *testing.T) {
 				State:  5,
 			},
 		},
-		RequestId: 3,
+		RequestId: "3",
 	}
 	if diff := deep.Equal(status, expectedStatus); diff != nil {
 		t.Error(diff)
@@ -163,7 +163,7 @@ func TestRequestStatus(t *testing.T) {
 func TestNewJobChain(t *testing.T) {
 	// Make a job chain.
 	jc := proto.JobChain{
-		RequestId: 3,
+		RequestId: "4",
 		Jobs: map[string]proto.Job{
 			"job1": {
 				Name:  "job1",

--- a/job-runner/main.go
+++ b/job-runner/main.go
@@ -14,8 +14,9 @@ import (
 )
 
 func main() {
-	// Make a chain repo.
-	chainRepo := chain.NewMemoryRepo()
+	// //////////////////////////////////////////////////////////////////////
+	// Chain repo
+	// //////////////////////////////////////////////////////////////////////
 	// We could alternatively make a redis-backed chain repo with something
 	// like the following:
 	//
@@ -26,16 +27,26 @@ func main() {
 	// 	IdleTimeout: 240 * time.Second,
 	// }
 	// chainRepo := chain.NewRedisRepo(redisConf)
+	chainRepo := chain.NewMemoryRepo()
 
-	// Make the API
+	// //////////////////////////////////////////////////////////////////////
+	// Runner factory and repo
+	// //////////////////////////////////////////////////////////////////////
 	runnerFactory := runner.NewFactory(external.JobFactory)
-	api := api.NewAPI(&router.Router{}, chainRepo, runnerFactory)
+	runnerRepo := runner.NewRepo()
 
-	// Make an HTTP server using API
+	// //////////////////////////////////////////////////////////////////////
+	// Traverser repo and factory
+	// //////////////////////////////////////////////////////////////////////
+	trRepo := chain.NewTraverserRepo()
+	trFactory := chain.NewTraverserFactory(chainRepo, runnerFactory, runnerRepo)
+
+	// //////////////////////////////////////////////////////////////////////
+	// API
+	// //////////////////////////////////////////////////////////////////////
+	api := api.NewAPI(&router.Router{}, trFactory, trRepo)
 	h := http.NewServeMux()
 	h.Handle("/api/", api.Router)
-
-	// Listen and serve
 	err := http.ListenAndServe(":9999", h)
 	log.Fatal(err)
 }

--- a/job-runner/runner/factory.go
+++ b/job-runner/runner/factory.go
@@ -11,7 +11,7 @@ import (
 // name is only used for testing with a mock RunnerFactory. An error is returned
 // if the job fails to instantiate or re-create itself.
 type Factory interface {
-	Make(jobType, jobName string, jobBytes []byte, requestId uint) (Runner, error)
+	Make(jobType, jobName string, jobBytes []byte, requestId string) (Runner, error)
 }
 
 type factory struct {
@@ -25,7 +25,7 @@ func NewFactory(jobFactory job.Factory) Factory {
 	}
 }
 
-func (f *factory) Make(jobType, jobName string, jobBytes []byte, requestId uint) (Runner, error) {
+func (f *factory) Make(jobType, jobName string, jobBytes []byte, requestId string) (Runner, error) {
 	// Instantiate a "blank" job of the given type
 	job, err := f.jobFactory.Make(jobType, jobName)
 	if err != nil {

--- a/job-runner/runner/runner_test.go
+++ b/job-runner/runner/runner_test.go
@@ -24,7 +24,7 @@ func TestFactory(t *testing.T) {
 	}
 	rf := runner.NewFactory(jf)
 
-	jr, err := rf.Make("jtype", "jname", []byte{}, 3)
+	jr, err := rf.Make("jtype", "jname", []byte{}, "abc")
 	if err != mock.ErrJob {
 		t.Errorf("err = nil, expected %s", mock.ErrJob)
 	}
@@ -37,7 +37,7 @@ func TestRunFail(t *testing.T) {
 	job := &mock.Job{
 		RunReturn: job.Return{State: proto.STATE_FAIL},
 	}
-	jr := runner.NewJobRunner(job, 3)
+	jr := runner.NewJobRunner(job, "abc")
 
 	completed := jr.Run(noJobData)
 	if completed != false {
@@ -50,7 +50,7 @@ func TestRunSuccess(t *testing.T) {
 		RunReturn:    job.Return{State: proto.STATE_COMPLETE},
 		AddedJobData: map[string]interface{}{"some": "thing"},
 	}
-	jr := runner.NewJobRunner(job, 3)
+	jr := runner.NewJobRunner(job, "abc")
 
 	jobData := make(map[string]interface{})
 
@@ -71,7 +71,7 @@ func TestRunStop(t *testing.T) {
 	job := &mock.Job{
 		RunBlock: runBlock,
 	}
-	jr := runner.NewJobRunner(job, 3)
+	jr := runner.NewJobRunner(job, "abc")
 
 	// Run the job and let it block
 	completedChan := make(chan bool)
@@ -97,7 +97,7 @@ func TestRunStatus(t *testing.T) {
 	job := &mock.Job{
 		StatusResp: expectedStatus,
 	}
-	jr := runner.NewJobRunner(job, 3)
+	jr := runner.NewJobRunner(job, "abc")
 
 	status := jr.Status()
 	if status != expectedStatus {

--- a/proto/s2s.go
+++ b/proto/s2s.go
@@ -21,7 +21,7 @@ type Job struct {
 // JobChain represents a directed acyclic graph of jobs for one request.
 // Job chains are identified by RequestId, which must be globally unique.
 type JobChain struct {
-	RequestId     uint                `json:"requestId"`     // unique identifier for the chain
+	RequestId     string              `json:"requestId"`     // unique identifier for the chain
 	Jobs          map[string]Job      `json:"jobs"`          // Job.Name => job
 	AdjacencyList map[string][]string `json:"adjacencyList"` // Job.Name => next jobs
 	State         byte                `json:"state"`         // STATE_* const
@@ -38,7 +38,7 @@ type JobStatus struct {
 
 // JobChainStatus represents the status of a job chain reported by the Job Runner.
 type JobChainStatus struct {
-	RequestId   uint        `json:"requestId"`
+	RequestId   string      `json:"requestId"`
 	JobStatuses JobStatuses `json:"jobStatuses"`
 }
 

--- a/test/mock/runner.go
+++ b/test/mock/runner.go
@@ -18,7 +18,7 @@ type RunnerFactory struct {
 	MakeErr         error
 }
 
-func (f *RunnerFactory) Make(jobType, jobName string, jobBytes []byte, requestId uint) (runner.Runner, error) {
+func (f *RunnerFactory) Make(jobType, jobName string, jobBytes []byte, requestId string) (runner.Runner, error) {
 	return f.RunnersToReturn[jobName], f.MakeErr
 }
 


### PR DESCRIPTION
* Change RequestId from uint to string
* Add chain.TraverserFactory and refactor api/ to use it
* Add chain.TraverserRepo arg api.NewAPI() instead of creating internally
* Make chain first arg to chain.NewTraverser()

All `proto.JobChain` to `chain.Traverser` logic and validation is now in `chain.TraverserFactory.Make()`--a single source of truth. The code (not tests) only makes traversers via the factory.