### PR TITLE
Update the grapher Node struct to store the Args that the node was cr…

### DIFF
--- a/job-runner/chain/redis_repo_test.go
+++ b/job-runner/chain/redis_repo_test.go
@@ -48,6 +48,19 @@ func initJc() *proto.JobChain {
 		AdjacencyList: map[string][]string{
 			"job1": []string{"job2", "job3"},
 		},
+		Jobs: map[string]proto.Job{
+			"j1": proto.Job{
+				Id:    "j1",
+				Type:  "something",
+				State: proto.STATE_PENDING,
+				Args: map[string]interface{}{
+					"k": "v",
+				},
+				Data: map[string]interface{}{
+					"some": "thing",
+				},
+			},
+		},
 	}
 }
 

--- a/proto/s2s.go
+++ b/proto/s2s.go
@@ -15,6 +15,7 @@ type Job struct {
 	Type  string                 `json:"type"`  // user-specific job type
 	Bytes []byte                 `json:"bytes"` // return value of Job.Serialize method
 	State byte                   `json:"state"` // STATE_* const
+	Args  map[string]interface{} `json:"args"`  // the jobArgs a job was created with
 	Data  map[string]interface{} `json:"data"`  // job-specific data during Job.Run
 }
 
@@ -22,8 +23,8 @@ type Job struct {
 // Job chains are identified by RequestId, which must be globally unique.
 type JobChain struct {
 	RequestId     string              `json:"requestId"`     // unique identifier for the chain
-	Jobs          map[string]Job      `json:"jobs"`          // Job.Name => job
-	AdjacencyList map[string][]string `json:"adjacencyList"` // Job.Name => next []Job.Name
+	Jobs          map[string]Job      `json:"jobs"`          // Job.Id => job
+	AdjacencyList map[string][]string `json:"adjacencyList"` // Job.Id => next []Job.Id
 	State         byte                `json:"state"`         // STATE_* const
 }
 

--- a/request-manager/grapher/grapher.go
+++ b/request-manager/grapher/grapher.go
@@ -49,9 +49,10 @@ type Graph struct {
 // Next defines all the out edges from Node, and Prev
 // defines all the in edges to Node.
 type Node struct {
-	Datum Payload          // Data stored at this Node
-	Next  map[string]*Node // out edges ( node name -> Node )
-	Prev  map[string]*Node // in edges ( node name -> Node )
+	Datum Payload                // Data stored at this Node
+	Next  map[string]*Node       // out edges ( node name -> Node )
+	Prev  map[string]*Node       // in edges ( node name -> Node )
+	Args  map[string]interface{} // the args the node was created with
 }
 
 // Payload defines the interface of structs that can be
@@ -359,8 +360,10 @@ func (o *Grapher) buildComponent(name string, nodeDefs map[string]*NodeSpec, nod
 					return nil, err
 				}
 
-				// Add the iterator to the node args
-				nodeArgsCopy[iterator] = i
+				// Add the iterator to the node args unless there is no iterator for this node
+				if iterator != "" {
+					nodeArgsCopy[iterator] = i
+				}
 
 				var g *Graph
 
@@ -585,6 +588,8 @@ func (o *Grapher) allArgsPresent(n *NodeSpec, args map[string]interface{}) bool 
 
 // Given a node definition and an args, copy args into a new map,
 // but also rename the arguments as defined in the "args" clause.
+// A shallow copy is sufficient because args values should never
+// change.
 func (o *Grapher) remapNodeArgs(n *NodeSpec, args map[string]interface{}) (map[string]interface{}, error) {
 	nodeArgs2 := map[string]interface{}{}
 	for _, arg := range n.Args {
@@ -692,6 +697,13 @@ func (o *Grapher) newNoopNode(name string, nodeArgs map[string]interface{}) (*No
 
 // newNode creates a node for the given job j
 func (o *Grapher) newNode(j *NodeSpec, nodeArgs map[string]interface{}) (*Node, error) {
+	// Make a copy of the nodeArgs before this node gets created and potentially
+	// adds additional keys to the nodeArgs. A shallow copy is sufficient because
+	// args values should never change.
+	originalArgs := map[string]interface{}{}
+	for k, v := range nodeArgs {
+		originalArgs[k] = v
+	}
 
 	// Make the name of this node unique within the request by assigning it an id.
 	name := fmt.Sprintf("%s@%d", j.Name, o.getNewNodeId())
@@ -711,6 +723,7 @@ func (o *Grapher) newNode(j *NodeSpec, nodeArgs map[string]interface{}) (*Node, 
 		Datum: rj,
 		Next:  map[string]*Node{},
 		Prev:  map[string]*Node{},
+		Args:  originalArgs, // Args is the nodeArgs map that this node was created with
 	}, nil
 }
 

--- a/request-manager/grapher/grapher_test.go
+++ b/request-manager/grapher/grapher_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-test/deep"
 	"github.com/square/spincycle/job"
 )
 
@@ -78,6 +79,49 @@ func testGrapher() *Grapher {
 		NoopNode:     cfg.NoopNode,
 	}
 	return o
+}
+
+func TestNodeArgs(t *testing.T) {
+	omg := testGrapher()
+	args := map[string]interface{}{
+		"cluster": "test-cluster-001",
+		"env":     "testing",
+	}
+
+	// create the graph
+	g, err := omg.CreateGraph("decommission-cluster", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, node := range g.Vertices {
+		// Verify that noop nodes do not have Args.
+		if strings.HasPrefix(name, "sequence_") || strings.HasPrefix(name, "repeat_") {
+			if len(node.Args) != 0 {
+				t.Errorf("node %s args = %#v, expected an empty map", name, node.Args)
+			}
+		}
+
+		// Check the Args on some nodes.
+		if strings.HasPrefix(name, "get-instances@") {
+			expectedArgs := map[string]interface{}{
+				"cluster": "test-cluster-001",
+			}
+			if diff := deep.Equal(node.Args, expectedArgs); diff != nil {
+				t.Error(diff)
+			}
+		}
+		if strings.HasPrefix(name, "prep-1@") {
+			expectedArgs := map[string]interface{}{
+				"cluster":   "test-cluster-001",
+				"env":       "testing",
+				"instances": []string{"node1", "node2", "node3", "node4"},
+			}
+			if diff := deep.Equal(node.Args, expectedArgs); diff != nil {
+				t.Error(diff)
+			}
+		}
+	}
 }
 
 func TestCreateDecomGraph(t *testing.T) {


### PR DESCRIPTION
…eated with, and also update the Job proto (which is part of the Job Chain) to store this as well

Goal: be able to tell what args a job was created with. For example, imagine you're looking at a job chain in the UI...if there are two jobs of the same type, how do you tell the difference between the two? By their jobArgs.

Solution: store a job's JobArgs directly in the proto.JobChain struct

Other considered solution: add a `Args() map[string]interface{}` method to the `Job` interface. that way, if you have a job, you can always run job.Args() to see what jobArgs it was created with. The downside with this solution is that spincycle has to recreate a job every time you want to see its args (so it would have to recreate lots of jobs every time you reload the web page displaying a job chain)