### PR TITLE
Various tweaks to job retry code

### DIFF
--- a/job-runner/runner/runner_test.go
+++ b/job-runner/runner/runner_test.go
@@ -53,10 +53,10 @@ func TestRunFail(t *testing.T) {
 		},
 	}
 	pJob := proto.Job{
-		Id:             "failJob",
-		Type:           "jtype",
-		Bytes:          []byte{},
-		RetriesAllowed: 2,
+		Id:    "failJob",
+		Type:  "jtype",
+		Bytes: []byte{},
+		Retry: 2,
 	}
 	// Create a mock rmClient that will keep track of how many JLs get sent through it.
 	jlsSent := 0
@@ -92,10 +92,10 @@ func TestRunSuccess(t *testing.T) {
 		},
 	}
 	pJob := proto.Job{
-		Id:             "successJob",
-		Type:           "jtype",
-		Bytes:          []byte{},
-		RetriesAllowed: 4,
+		Id:    "successJob",
+		Type:  "jtype",
+		Bytes: []byte{},
+		Retry: 4,
 	}
 	// Create a mock rmClient that will keep track of how many JLs get sent through it.
 	jlsSent := 0
@@ -125,11 +125,11 @@ func TestRunStop(t *testing.T) {
 		},
 	}
 	pJob := proto.Job{
-		Id:             "successJob",
-		Type:           "jtype",
-		Bytes:          []byte{},
-		RetriesAllowed: 1,
-		RetryDelay:     30, // important...the runner will sleep for 30 seconds after the job fails the first time
+		Id:        "successJob",
+		Type:      "jtype",
+		Bytes:     []byte{},
+		Retry:     1,
+		RetryWait: 30000, // important...the runner will sleep for 30 seconds after the job fails the first time
 	}
 	rmc := &mock.RMClient{}
 	jr := runner.NewRunner(pJob, mJob, "abc", rmc)
@@ -142,7 +142,7 @@ func TestRunStop(t *testing.T) {
 
 	// Sleep for a second to allow the runner to get to the state where it's sleeping for the
 	// duration of the retry delay.
-	time.Sleep(1000 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	err := jr.Stop()
 	if err != nil {
 		t.Errorf("err = %s, expected nil", err)

--- a/proto/s2s.go
+++ b/proto/s2s.go
@@ -11,15 +11,14 @@ import (
 // Job represents one job in a job chain. Jobs are identified by Id, which
 // must be unique within a job chain.
 type Job struct {
-	Id    string                 `json:"id"`    // unique id
-	Type  string                 `json:"type"`  // user-specific job type
-	Bytes []byte                 `json:"bytes"` // return value of Job.Serialize method
-	State byte                   `json:"state"` // STATE_* const
-	Args  map[string]interface{} `json:"args"`  // the jobArgs a job was created with
-	Data  map[string]interface{} `json:"data"`  // job-specific data during Job.Run
-
-	RetriesAllowed int `json:"retriesAllowed"` // the number of times a job can be retried
-	RetryDelay     int `json:"retryDelay"`     // delay, in seconds, between retries
+	Id        string                 `json:"id"`        // unique id
+	Type      string                 `json:"type"`      // user-specific job type
+	Bytes     []byte                 `json:"bytes"`     // return value of Job.Serialize method
+	State     byte                   `json:"state"`     // STATE_* const
+	Args      map[string]interface{} `json:"args"`      // the jobArgs a job was created with
+	Data      map[string]interface{} `json:"data"`      // job-specific data during Job.Run
+	Retry     uint                   `json:"retry"`     // retry N times if first run fails
+	RetryWait uint                   `json:"retryWait"` // wait time (milliseconds) between retries
 }
 
 // JobChain represents a directed acyclic graph of jobs for one request.
@@ -50,20 +49,20 @@ type Request struct {
 
 // JobLog represents a log entry for a finished job.
 type JobLog struct {
-	RequestId string `json:"requestId"` // the request that the job belongs to
-	JobId     string `json:"jobId"`     // the id of the job
-	Type      string `json:"type"`      // the type of the job
+	// These three fields uniquely identify an entry in the job log.
+	RequestId string `json:"requestId"`
+	JobId     string `json:"jobId"`
+	Try       uint   `json:"try"` // try number N of 1 + Job.Retry
 
-	StartedAt  time.Time `json:"startedAt"`  // when the request was sent to the job runner
-	FinishedAt time.Time `json:"finishedAt"` // when the job runner finished the request. doesn't indicate success/failure
+	Type       string    `json:"type"`       // the type of the job
+	StartedAt  time.Time `json:"startedAt"`  // when the job runner started the job
+	FinishedAt time.Time `json:"finishedAt"` // when the job returned, regardless of state
 
 	State  byte   `json:"state"`  // STATE_* const
 	Exit   int64  `json:"exit"`   // unix exit code
 	Error  string `json:"error"`  // error message
 	Stdout string `json:"stdout"` // stdout output
 	Stderr string `json:"stderr"` // stderr output
-
-	Attempt int `json:"attempt"` // the attempt number for running the job (ex: 1 for first, 2 for second)
 }
 
 // JobStatus represents the status of one job in a job chain.

--- a/request-manager/grapher/grapher.go
+++ b/request-manager/grapher/grapher.go
@@ -50,12 +50,12 @@ type Graph struct {
 // should be retried on error. Next defines all the out edges
 // from Node, and Prev defines all the in edges to Node.
 type Node struct {
-	Datum      Payload                // Data stored at this Node
-	Next       map[string]*Node       // out edges ( node name -> Node )
-	Prev       map[string]*Node       // in edges ( node name -> Node )
-	Args       map[string]interface{} // the args the node was created with
-	Retries    int                    // the number of times to retry a node
-	RetryDelay int                    // the time, in seconds, to sleep between retries
+	Datum     Payload                // Data stored at this Node
+	Next      map[string]*Node       // out edges ( node name -> Node )
+	Prev      map[string]*Node       // in edges ( node name -> Node )
+	Args      map[string]interface{} // the args the node was created with
+	Retry     uint                   // retry N times if first run fails
+	RetryWait uint                   // wait time (milliseconds) between retries
 }
 
 // Payload defines the interface of structs that can be
@@ -81,9 +81,9 @@ type NodeSpec struct {
 	Sets         []string   `yaml:"sets"`     // expected job args to be set
 	Dependencies []string   `yaml:"deps"`     // nodes with out-edges leading to this node
 
-	// Retries only apply to nodes with category="job". Fields are ignored for "sequence"s
-	Retries    int `yaml:"retries"`    // the number of times to retry a "job" that fails
-	RetryDelay int `yaml:"retryDelay"` // the time, in seconds, to sleep between "job" retries
+	// Retry only apply to nodes with category="job". Fields are ignored for "sequence"s
+	Retry     uint `yaml:"retry"`     // retry N times if first run fails
+	RetryWait uint `yaml:"retryWait"` // wait time (milliseconds) between retries
 }
 
 // NodeArg defines the structure expected from the yaml file to define a job's args.
@@ -727,12 +727,12 @@ func (o *Grapher) newNode(j *NodeSpec, nodeArgs map[string]interface{}) (*Node, 
 	}
 
 	return &Node{
-		Datum:      rj,
-		Next:       map[string]*Node{},
-		Prev:       map[string]*Node{},
-		Args:       originalArgs, // Args is the nodeArgs map that this node was created with
-		Retries:    j.Retries,
-		RetryDelay: j.RetryDelay,
+		Datum:     rj,
+		Next:      map[string]*Node{},
+		Prev:      map[string]*Node{},
+		Args:      originalArgs, // Args is the nodeArgs map that this node was created with
+		Retry:     j.Retry,
+		RetryWait: j.RetryWait,
 	}, nil
 }
 

--- a/request-manager/grapher/grapher_test.go
+++ b/request-manager/grapher/grapher_test.go
@@ -118,7 +118,7 @@ func TestNodeArgs(t *testing.T) {
 	}
 }
 
-func TestNodeRetries(t *testing.T) {
+func TestNodeRetry(t *testing.T) {
 	omg := testGrapher()
 	args := map[string]interface{}{
 		"cluster": "test-cluster-001",
@@ -136,18 +136,18 @@ func TestNodeRetries(t *testing.T) {
 	for name, node := range g.Vertices {
 		if strings.HasPrefix(name, "get-instances@") {
 			found = true
-			if node.Retries != 3 {
-				t.Errorf("%s node retries = %d, expected %d", name, node.Retries, 3)
+			if node.Retry != 3 {
+				t.Errorf("%s node retries = %d, expected %d", name, node.Retry, 3)
 			}
-			if node.RetryDelay != 10 {
-				t.Errorf("%s node retry delay = %d, expected %d", name, node.RetryDelay, 10)
+			if node.RetryWait != 10 {
+				t.Errorf("%s node retry delay = %d, expected %d", name, node.RetryWait, 10)
 			}
 		} else {
-			if node.Retries != 0 {
-				t.Errorf("%s node retries = %d, expected %d", name, node.Retries, 0)
+			if node.Retry != 0 {
+				t.Errorf("%s node retries = %d, expected %d", name, node.Retry, 0)
 			}
-			if node.RetryDelay != 0 {
-				t.Errorf("%s node retry delay = %d, expected %d", name, node.RetryDelay, 0)
+			if node.RetryWait != 0 {
+				t.Errorf("%s node retry delay = %d, expected %d", name, node.RetryWait, 0)
 			}
 		}
 	}

--- a/request-manager/grapher/test/example-requests.yaml
+++ b/request-manager/grapher/test/example-requests.yaml
@@ -17,8 +17,8 @@ sequences:
             given: cluster
         sets: [instances]
         deps: []
-        retries: 3
-        retryDelay: 10
+        retry: 3
+        retryWait: 10
       prep-1:
         category: job
         type: prep-job-1
@@ -41,8 +41,8 @@ sequences:
           - expected: instances
             given: instances
         deps: [get-instances]
-        retries: 3     # this should get ignored
-        retryDelay: 10 # this should get ignored
+        retry: 3      # this should be ignored
+        retryWait: 10 # this should be ignored
       decommission-instances:
         category: sequence
         type: decommission-instance

--- a/request-manager/request/db.go
+++ b/request-manager/request/db.go
@@ -25,12 +25,12 @@ const (
 
 	// JL queries.
 	createJL = "INSERT INTO job_log (request_id, job_id, type, started_at, finished_at, state, `exit`, " +
-		"error, stdout, stderr, attempt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-	selectLatestJL = "SELECT request_id, job_id, state, started_at, finished_at, error, `exit`, stdout, stderr, attempt " +
-		"FROM job_log WHERE request_id = ? AND job_id = ? ORDER BY attempt DESC LIMIT 1"
+		"error, stdout, stderr, try) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+	selectLatestJL = "SELECT request_id, job_id, state, started_at, finished_at, error, `exit`, stdout, stderr, try " +
+		"FROM job_log WHERE request_id = ? AND job_id = ? ORDER BY try DESC LIMIT 1"
 	// Select the job id and state of all jobs in a request, using the latest JL for each job.
 	selectRequestLatestJLStates = "SELECT j1.job_id, j1.state FROM job_log j1 LEFT JOIN job_log j2 ON (j1.request_id = " +
-		"j2.request_id AND j1.job_id = j2.job_id AND j1.attempt < j2.attempt) WHERE j1.request_id = ? AND j2.attempt IS NULL"
+		"j2.request_id AND j1.job_id = j2.job_id AND j1.try < j2.try) WHERE j1.request_id = ? AND j2.try IS NULL"
 )
 
 // A DBAccessor persists requests to a database.
@@ -264,7 +264,7 @@ func (d *dbAccessor) GetLatestJL(requestId, jobId string) (proto.JobLog, error) 
 		&jl.Exit,
 		&jl.Stdout,
 		&jl.Stderr,
-		&jl.Attempt)
+		&jl.Try)
 	switch {
 	case err == sql.ErrNoRows:
 		return jl, NewErrNotFound("job log")
@@ -288,7 +288,7 @@ func (d *dbAccessor) SaveJL(jl proto.JobLog) error {
 		&jl.Error,
 		&jl.Stdout,
 		&jl.Stderr,
-		&jl.Attempt)
+		&jl.Try)
 
 	return err
 }

--- a/request-manager/request/db_test.go
+++ b/request-manager/request/db_test.go
@@ -306,7 +306,7 @@ func TestCreateGetJL(t *testing.T) {
 	jl := proto.JobLog{
 		RequestId: reqId,
 		JobId:     jobId,
-		Attempt:   1,
+		Try:       1,
 	}
 
 	// Create a jl in the db.
@@ -318,7 +318,7 @@ func TestCreateGetJL(t *testing.T) {
 	jl = proto.JobLog{
 		RequestId: reqId,
 		JobId:     jobId,
-		Attempt:   2,
+		Try:       2,
 	}
 
 	// Create a second jl in the db.
@@ -348,33 +348,33 @@ func TestGetRequestJobStatuses(t *testing.T) {
 		RequestId: reqId1,
 		JobId:     jobId,
 		State:     proto.STATE_FAIL,
-		Attempt:   1, // first attempt
+		Try:       1, // first attempt
 	}
 	jl2 := proto.JobLog{
 		RequestId: reqId1,
 		JobId:     jobId,
 		State:     proto.STATE_COMPLETE,
-		Attempt:   2, // second attempt
+		Try:       2, // second attempt
 	}
 	jobId = "job2"
 	jl3 := proto.JobLog{
 		RequestId: reqId1,
 		JobId:     jobId,
 		State:     proto.STATE_FAIL,
-		Attempt:   1, // first attempt
+		Try:       1, // first attempt
 	}
 	jl4 := proto.JobLog{
 		RequestId: reqId1,
 		JobId:     jobId,
 		State:     proto.STATE_FAIL,
-		Attempt:   2, // second attempt
+		Try:       2, // second attempt
 	}
 	jobId = "job3"
 	jl5 := proto.JobLog{
 		RequestId: reqId1,
 		JobId:     jobId,
 		State:     proto.STATE_FAIL,
-		Attempt:   1,
+		Try:       1,
 	}
 	reqId2 := util.UUID() // this one has a different request id
 	jobId = "job4"
@@ -382,7 +382,7 @@ func TestGetRequestJobStatuses(t *testing.T) {
 		RequestId: reqId2,
 		JobId:     jobId,
 		State:     proto.STATE_FAIL,
-		Attempt:   1,
+		Try:       1,
 	}
 	jls := []proto.JobLog{jl1, jl2, jl3, jl4, jl5, jl6}
 

--- a/request-manager/request/manager.go
+++ b/request-manager/request/manager.go
@@ -108,11 +108,11 @@ func (m *manager) CreateRequest(reqParams proto.CreateRequestParams) (proto.Requ
 			return req, err
 		}
 		job := proto.Job{
-			Type:           node.Datum.Type(),
-			Id:             node.Datum.Name(),
-			Bytes:          bytes,
-			RetriesAllowed: node.Retries,
-			RetryDelay:     node.RetryDelay,
+			Type:      node.Datum.Type(),
+			Id:        node.Datum.Name(),
+			Bytes:     bytes,
+			Retry:     node.Retry,
+			RetryWait: node.RetryWait,
 		}
 		jc.Jobs[name] = job
 	}

--- a/request-manager/resources/request_manager_schema.sql
+++ b/request-manager/resources/request_manager_schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `requests` (
+CREATE TABLE IF NOT EXISTS `requests` (
   `id`             BINARY(32) NOT NULL,
   `type`           VARBINARY(75) NOT NULL,
   `state`          TINYINT NOT NULL DEFAULT 0,
@@ -14,7 +14,7 @@ CREATE TABLE `requests` (
   INDEX state (`state`)
 );
 
-CREATE TABLE `raw_requests` (
+CREATE TABLE IF NOT EXISTS `raw_requests` (
   `request_id` BINARY(32) NOT NULL,
   `request`    BLOB NOT NULL,
   `job_chain`  BLOB NOT NULL,
@@ -22,9 +22,10 @@ CREATE TABLE `raw_requests` (
   PRIMARY KEY (`request_id`)
 );
 
-CREATE TABLE `job_log` (
+CREATE TABLE IF NOT EXISTS `job_log` (
   `request_id`  BINARY(32) NOT NULL,
   `job_id`      VARBINARY(100) NOT NULL,
+  `try`         SMALLINT NOT NULL DEFAULT 0,
   `type`        VARBINARY(75) NOT NULL,
   `state`       TINYINT NOT NULL DEFAULT 0,
   `status`      TEXT NULL DEFAULT NULL,
@@ -34,9 +35,6 @@ CREATE TABLE `job_log` (
   `exit`        TINYINT UNSIGNED NULL DEFAULT NULL,
   `stdout`      TEXT NULL DEFAULT NULL,
   `stderr`      TEXT NULL DEFAULT NULL,
-  `attempt`     SMALLINT NOT NULL DEFAULT 1,
 
-  PRIMARY KEY (`request_id`, `job_id`, `attempt`),
-  INDEX state (`state`),
-  INDEX type (`type`)
+  PRIMARY KEY (`request_id`, `job_id`, `try`)
 );


### PR DESCRIPTION
* Standardize on term "(re)try" (singular and plural); remove "attempt"
* Rename proto.Job.RetriesAllowed -> .Retries and .RetryDelay to .RetryWait
* Rename proto.JobLog.Attempt -> .Try
* Rename job_log.attempt col -> .try
* Change job_log.try col default from 1 -> 0 (to detect bad rows)
* Remove extra (unused?) indexes on job_log table
* Change RetryWait from seconds to milliseconds
* Make var names more consistent and/or clear (finalState, pJob, runnableJob)
* Factor pJob fields out of Runner.Run() (bake into instance in NewRunner())