### PR TITLE
Remove noop-node from request spec

### DIFF
--- a/request-manager/bin/main.go
+++ b/request-manager/bin/main.go
@@ -61,9 +61,6 @@ func main() {
 		for k, v := range grapherCfg.Sequences {
 			allGrapherCfgs.Sequences[k] = v
 		}
-		if grapherCfg.NoopNode != nil {
-			allGrapherCfgs.NoopNode = grapherCfg.NoopNode
-		}
 	}
 	idf := id.NewGeneratorFactory(4, 100) // generate 4-character ids for jobs
 	grf := grapher.NewGrapherFactory(external.JobFactory, &allGrapherCfgs, idf)

--- a/request-manager/grapher/noop.go
+++ b/request-manager/grapher/noop.go
@@ -1,0 +1,59 @@
+package grapher
+
+import (
+	"github.com/square/spincycle/job"
+	"github.com/square/spincycle/proto"
+)
+
+// noop is the default node spec for sequence fan-out (source) and fan-in (sink) nodes.
+var noopSpec = &NodeSpec{
+	Name:     "noop",
+	Category: "job",
+	NodeType: "noop",
+}
+
+// noopJob is a no-op job that does nothing and always returns success. It's used
+// as the default for sequence start and end.
+type noopJob struct {
+	jobType string
+	jobName string
+}
+
+func (j *noopJob) Create(jobArgs map[string]interface{}) error {
+	return nil
+}
+
+func (j *noopJob) Serialize() ([]byte, error) {
+	return nil, nil
+}
+
+func (j *noopJob) Deserialize(bytes []byte) error {
+	return nil
+}
+
+func (j *noopJob) Run(jobData map[string]interface{}) (job.Return, error) {
+	ret := job.Return{
+		Exit:   0,
+		Error:  nil,
+		Stdout: "",
+		Stderr: "",
+		State:  proto.STATE_COMPLETE,
+	}
+	return ret, nil
+}
+
+func (j *noopJob) Status() string {
+	return "nop"
+}
+
+func (j *noopJob) Stop() error {
+	return nil
+}
+
+func (j *noopJob) Type() string {
+	return j.jobType
+}
+
+func (j *noopJob) Name() string {
+	return j.jobName
+}

--- a/request-manager/grapher/spec.go
+++ b/request-manager/grapher/spec.go
@@ -1,7 +1,6 @@
 package grapher
 
 import (
-	"fmt"
 	"io/ioutil"
 
 	"gopkg.in/yaml.v2"
@@ -55,7 +54,6 @@ type ArgSpec struct {
 // All Sequences in the yaml. Also contains the user defined no-op job.
 type Config struct {
 	Sequences map[string]*SequenceSpec `yaml:"sequences"`
-	NoopNode  *NodeSpec                `yaml:"noop-node"`
 }
 
 // ReadConfig will read from configFile and return a Config that the user
@@ -78,12 +76,6 @@ func ReadConfig(configFile string) (*Config, error) {
 			node.Name = nodeName
 		}
 	}
-
-	if cfg.NoopNode == nil {
-		return nil, fmt.Errorf("Noop node spec is missing")
-	}
-
-	cfg.NoopNode.Name = "noop-job"
 
 	return cfg, nil
 }

--- a/request-manager/test/coverage
+++ b/request-manager/test/coverage
@@ -1,0 +1,3 @@
+#!/bin/sh
+go test -coverprofile=coverage.out
+go tool cover -html=coverage.out

--- a/request-manager/test/specs/a-b-c.yaml
+++ b/request-manager/test/specs/a-b-c.yaml
@@ -31,6 +31,3 @@ sequences:
         category: job
         type: cJobType
         deps: [b]
-noop-node:
-  category: job
-  type: no-op

--- a/request-manager/test/specs/bad-each-001.yaml
+++ b/request-manager/test/specs/bad-each-001.yaml
@@ -33,6 +33,3 @@ sequences:
         args:
           - expected: container
             given: instance
-noop-node:
-  category: job
-  type: no-op

--- a/request-manager/test/specs/decomm.yaml
+++ b/request-manager/test/specs/decomm.yaml
@@ -139,6 +139,3 @@ sequences:
             given: instance
         sets: []
         deps: [decom-2]
-noop-node:
-  category: job
-  type: no-op

--- a/request-manager/test/specs/opt-args-001.yaml
+++ b/request-manager/test/specs/opt-args-001.yaml
@@ -1,6 +1,3 @@
-noop-node:
-  category: job
-  type: noop
 sequences:
   req:
     args:


### PR DESCRIPTION
Removes the requirement for having this stanza in request specs:
```yaml
noop-node:
  category: job
  type: noop
```

There's now a built-in, default no-op job that is used if the user-provided job factory cannot create a job of type `noop`.