### PR TITLE
Refactor job-runner/chain and fix spinc ps output

### DIFF
--- a/job-runner/chain/chain_test.go
+++ b/job-runner/chain/chain_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017, Square, Inc.
+// Copyright 2017-2018, Square, Inc.
 
 package chain
 
@@ -39,7 +39,7 @@ func TestFirstJobOne(t *testing.T) {
 	}
 	c := NewChain(jc)
 
-	expectedFirstJob := c.JobChain.Jobs["job1"]
+	expectedFirstJob := jc.Jobs["job1"]
 	firstJob, err := c.FirstJob()
 
 	if !reflect.DeepEqual(firstJob, expectedFirstJob) {
@@ -59,7 +59,7 @@ func TestLastJobMultiple(t *testing.T) {
 	}
 	c := NewChain(jc)
 
-	_, err := c.LastJob()
+	_, err := c.lastJob()
 	if err == nil {
 		t.Errorf("expected an error, but did not get one")
 	}
@@ -76,8 +76,8 @@ func TestLastJobOne(t *testing.T) {
 	}
 	c := NewChain(jc)
 
-	expectedLastJob := c.JobChain.Jobs["job4"]
-	lastJob, err := c.LastJob()
+	expectedLastJob := jc.Jobs["job4"]
+	lastJob, err := c.lastJob()
 
 	if !reflect.DeepEqual(lastJob, expectedLastJob) {
 		t.Errorf("lastJob = %v, expected %v", lastJob, expectedLastJob)
@@ -98,7 +98,7 @@ func TestNextJobs(t *testing.T) {
 	}
 	c := NewChain(jc)
 
-	expectedNextJobs := proto.Jobs{c.JobChain.Jobs["job2"], c.JobChain.Jobs["job3"]}
+	expectedNextJobs := proto.Jobs{jc.Jobs["job2"], jc.Jobs["job3"]}
 	sort.Sort(expectedNextJobs)
 	nextJobs := c.NextJobs("job1")
 	sort.Sort(nextJobs)
@@ -125,16 +125,16 @@ func TestPreviousJobs(t *testing.T) {
 	}
 	c := NewChain(jc)
 
-	expectedPreviousJobs := proto.Jobs{c.JobChain.Jobs["job2"], c.JobChain.Jobs["job3"]}
+	expectedPreviousJobs := proto.Jobs{jc.Jobs["job2"], jc.Jobs["job3"]}
 	sort.Sort(expectedPreviousJobs)
-	previousJobs := c.PreviousJobs("job4")
+	previousJobs := c.previousJobs("job4")
 	sort.Sort(previousJobs)
 
 	if !reflect.DeepEqual(previousJobs, expectedPreviousJobs) {
 		t.Errorf("previousJobs = %v, want %v", previousJobs, expectedPreviousJobs)
 	}
 
-	previousJobs = c.PreviousJobs("job1")
+	previousJobs = c.previousJobs("job1")
 
 	if len(previousJobs) != 0 {
 		t.Errorf("previousJobs count = %d, want 0", len(previousJobs))
@@ -254,8 +254,8 @@ func TestSetJobState(t *testing.T) {
 	c := NewChain(jc)
 
 	c.SetJobState("job1", proto.STATE_COMPLETE)
-	if c.JobChain.Jobs["job1"].State != proto.STATE_COMPLETE {
-		t.Errorf("State = %d, want %d", c.JobChain.Jobs["job1"].State, proto.STATE_COMPLETE)
+	if jc.Jobs["job1"].State != proto.STATE_COMPLETE {
+		t.Errorf("State = %d, want %d", jc.Jobs["job1"].State, proto.STATE_COMPLETE)
 	}
 }
 
@@ -264,8 +264,8 @@ func TestSetState(t *testing.T) {
 	c := NewChain(jc)
 
 	c.SetState(proto.STATE_RUNNING)
-	if c.JobChain.State != proto.STATE_RUNNING {
-		t.Errorf("State = %d, want %d", c.JobChain.State, proto.STATE_RUNNING)
+	if c.State() != proto.STATE_RUNNING {
+		t.Errorf("State = %d, want %d", c.State(), proto.STATE_RUNNING)
 	}
 }
 

--- a/job-runner/chain/memory_repo.go
+++ b/job-runner/chain/memory_repo.go
@@ -1,4 +1,4 @@
-// Copyright 2017, Square, Inc.
+// Copyright 2017-2018, Square, Inc.
 
 package chain
 

--- a/job-runner/chain/redis_repo.go
+++ b/job-runner/chain/redis_repo.go
@@ -5,7 +5,6 @@ package chain
 import (
 	"encoding/json"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/garyburd/redigo/redis"
@@ -111,7 +110,6 @@ func (r *RedisRepo) Get(id string) (*chain, error) {
 	if err != nil {
 		return nil, err
 	}
-	chain.RWMutex = &sync.RWMutex{} // Need to initialize the mutex
 
 	return chain, nil
 }
@@ -201,5 +199,5 @@ func (r *RedisRepo) fmtIdKey(id string) string {
 // fmtChainKey takes a Chain and returns the key where that Chain is stored in
 // redis.
 func (r *RedisRepo) fmtChainKey(chain *chain) string {
-	return r.fmtIdKey(chain.JobChain.RequestId)
+	return r.fmtIdKey(chain.RequestId())
 }

--- a/job-runner/chain/redis_repo_test.go
+++ b/job-runner/chain/redis_repo_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017, Square, Inc.
+// Copyright 2017-2018, Square, Inc.
 
 package chain_test
 
@@ -128,7 +128,7 @@ func TestGetSet(t *testing.T) {
 	c := chain.NewChain(initJc())
 
 	// Should not exist before Set
-	ret, err := repo.Get(c.JobChain.RequestId)
+	ret, err := repo.Get(c.RequestId())
 	if ret != nil {
 		t.Error("request id exists before SET is executed")
 	}
@@ -138,7 +138,7 @@ func TestGetSet(t *testing.T) {
 		t.Errorf("error in Set: %v", err)
 	}
 
-	gotC, err := repo.Get(c.JobChain.RequestId)
+	gotC, err := repo.Get(c.RequestId())
 	if err != nil {
 		t.Errorf("error in Get: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestRemove(t *testing.T) {
 
 	repo.Set(c)
 
-	err := repo.Remove(c.JobChain.RequestId)
+	err := repo.Remove(c.RequestId())
 	if err != nil {
 		t.Errorf("error in Remove: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestRemove(t *testing.T) {
 	}
 
 	// We expect an error if the key doesn't exist
-	err = repo.Remove(c.JobChain.RequestId)
+	err = repo.Remove(c.RequestId())
 	if err != chain.ErrNotFound {
 		t.Error("Did not return expected key not found error")
 	}
@@ -247,27 +247,28 @@ func TestGetAll(t *testing.T) {
 		default:
 			t.Fatalf("got chain with nonexistent RequestId: %s", c.RequestId)
 		}
-		if diff := deep.Equal(c.JobChain, expect); diff != nil {
+		if diff := deep.Equal(c.JobChain(), expect); diff != nil {
 			t.Error(c.RequestId, diff)
 		}
+		running := c.Running()
 		if expectRunning {
-			if len(c.Running) != 1 {
+			if len(running) != 1 {
 				test.Dump(c)
-				t.Errorf("chain.Running has %d keys, expected 1", len(c.Running))
+				t.Errorf("chain.Running has %d keys, expected 1", len(running))
 			}
-			j, ok := c.Running[job]
+			j, ok := running[job]
 			if !ok {
 				t.Errorf("%s not set in chain.Running, expected it to be set", job)
 			}
-			if j.StartTs <= 0 {
-				t.Errorf("chain.Running[%s].StartTs = %d, expected > 0", job, j.StartTs)
+			if j.StartedAt <= 0 {
+				t.Errorf("chain.Running[%s].StartTs = %d, expected > 0", job, j.StartedAt)
 			}
 		} else {
-			if len(c.Running) != 0 {
+			if len(running) != 0 {
 				test.Dump(c)
-				t.Errorf("chain.Running has %d keys, expected 0", len(c.Running))
+				t.Errorf("chain.Running has %d keys, expected 0", len(running))
 			}
-			_, ok := c.Running[job]
+			_, ok := running[job]
 			if ok {
 				t.Errorf("%s set in chain.Running, expected Running map to be empty", job)
 			}

--- a/job-runner/runner/repo.go
+++ b/job-runner/runner/repo.go
@@ -11,8 +11,8 @@ import (
 // Repo is a small wrapper around a concurrent map that provides the ability to
 // store and retreive Runners in a thread-safe way.
 type Repo interface {
-	Set(key string, value Runner)
-	Remove(key string)
+	Set(jobId string, runner Runner)
+	Remove(jobId string)
 	Items() (map[string]Runner, error)
 }
 
@@ -27,26 +27,24 @@ func NewRepo() Repo {
 }
 
 // Set sets a Runner in the repo.
-func (r *repo) Set(key string, value Runner) {
-	r.c.Set(key, value)
+func (r *repo) Set(jobId string, runner Runner) {
+	r.c.Set(jobId, runner)
 }
 
 // Remove removes a runner from the repo.
-func (r *repo) Remove(key string) {
-	r.c.Remove(key)
+func (r *repo) Remove(jobId string) {
+	r.c.Remove(jobId)
 }
 
-// Items returns a map of key => Runner with all the Runners in the repo.
+// Items returns a map of jobId => Runner with all the Runners in the repo.
 func (r *repo) Items() (map[string]Runner, error) {
-	runners := map[string]Runner{} // key => runner
-	vals := r.c.Items()
-	for key, val := range vals {
-		runner, ok := val.(Runner)
+	runners := map[string]Runner{} // jobId => runner
+	for jobId, v := range r.c.Items() {
+		runner, ok := v.(Runner)
 		if !ok {
-			return runners, fmt.Errorf("invalid runner in repo for key=%s", key) // should be impossible
+			return runners, fmt.Errorf("invalid runner in repo for jobId=%s", jobId) // should be impossible
 		}
-		runners[key] = runner
+		runners[jobId] = runner
 	}
-
 	return runners, nil
 }

--- a/job-runner/status/status.go
+++ b/job-runner/status/status.go
@@ -33,14 +33,14 @@ func (m *manager) Running() ([]proto.JobStatus, error) {
 
 	running := []proto.JobStatus{}
 	for _, c := range chains {
-		for jobId, j := range c.Running {
-			startTime := time.Unix(0, j.StartTs)
+		for jobId, runningJob := range c.Running {
+			startTime := time.Unix(0, runningJob.StartTs)
 			s := proto.JobStatus{
 				RequestId: c.RequestId(),
 				JobId:     jobId,
 				State:     proto.STATE_RUNNING, // must be since it's in chain.Running
 				Runtime:   time.Now().Sub(startTime).Seconds(),
-				N:         j.N,
+				N:         runningJob.N,
 			}
 			running = append(running, s)
 		}

--- a/job-runner/status/status.go
+++ b/job-runner/status/status.go
@@ -4,8 +4,6 @@
 package status
 
 import (
-	"time"
-
 	"github.com/square/spincycle/job-runner/chain"
 	"github.com/square/spincycle/proto"
 )
@@ -33,16 +31,8 @@ func (m *manager) Running() ([]proto.JobStatus, error) {
 
 	running := []proto.JobStatus{}
 	for _, c := range chains {
-		for jobId, runningJob := range c.Running {
-			startTime := time.Unix(0, runningJob.StartTs)
-			s := proto.JobStatus{
-				RequestId: c.RequestId(),
-				JobId:     jobId,
-				State:     proto.STATE_RUNNING, // must be since it's in chain.Running
-				Runtime:   time.Now().Sub(startTime).Seconds(),
-				N:         runningJob.N,
-			}
-			running = append(running, s)
+		for _, jobStatus := range c.Running() {
+			running = append(running, jobStatus)
 		}
 	}
 

--- a/job-runner/status/status_test.go
+++ b/job-runner/status/status_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestRunning(t *testing.T) {
+	now := time.Now().UnixNano()
 
 	jc1 := &proto.JobChain{
 		RequestId: "chain1",
@@ -76,35 +77,39 @@ func TestRunning(t *testing.T) {
 		{
 			RequestId: "chain1", // longer runtime because of delay ^
 			JobId:     "job1",
+			Type:      "type1",
 			State:     proto.STATE_RUNNING,
 			N:         1,
+			Args:      map[string]interface{}{},
 		},
 		{
 			RequestId: "chain2",
 			JobId:     "job2",
+			Type:      "type2",
 			State:     proto.STATE_RUNNING,
 			N:         1,
+			Args:      map[string]interface{}{},
 		},
 	}
 
-	if got[0].Runtime <= 0 {
-		t.Errorf("job1 runtime %f, expected > 0", got[0].Runtime)
+	if got[0].StartedAt < now {
+		t.Errorf("job1 started %d < %d", got[0].StartedAt, now)
 	}
-	if got[1].Runtime <= 0 {
-		t.Errorf("job2 runtime %f, expected > 0", got[1].Runtime)
+	if got[1].StartedAt <= 0 {
+		t.Errorf("job2 runtime %f, expected > 0", got[1].StartedAt)
 	}
 
-	// Runtime is nondeterministic
-	expect[0].Runtime = got[0].Runtime
-	expect[1].Runtime = got[1].Runtime
+	// StartedAt is nondeterministic
+	expect[0].StartedAt = got[0].StartedAt
+	expect[1].StartedAt = got[1].StartedAt
 
 	if diff := deep.Equal(got, expect); diff != nil {
 		test.Dump(got)
 		t.Error(diff)
 	}
 
-	// chain1 runtime should be > chain2
-	if got[0].Runtime <= got[1].Runtime {
-		t.Errorf("runtime chain1 %f <= chain2 %f", got[0].Runtime, got[1].Runtime)
+	// chain1 should before chain2
+	if got[0].StartedAt >= got[1].StartedAt {
+		t.Errorf("started chain1 %d >= chain2 %d", got[0].StartedAt, got[1].StartedAt)
 	}
 }

--- a/request-manager/status/manager.go
+++ b/request-manager/status/manager.go
@@ -32,7 +32,7 @@ type Filter struct {
 var NoFilter Filter
 
 const (
-	ORDER_BY_RUNTIME byte = iota
+	ORDER_BY_START_TIME byte = iota
 )
 
 type manager struct {
@@ -56,10 +56,10 @@ func (m *manager) Running(f Filter) (proto.RunningStatus, error) {
 	}
 
 	switch f.OrderBy {
-	case ORDER_BY_RUNTIME:
-		sort.Sort(proto.JobStatusByRuntime(running))
+	case ORDER_BY_START_TIME:
+		sort.Sort(proto.JobStatusByStartTime(running))
 	default:
-		sort.Sort(proto.JobStatusByRuntime(running))
+		sort.Sort(proto.JobStatusByStartTime(running))
 	}
 
 	if f.Limit > 0 && len(running) > f.Limit {

--- a/spinc/cmd/ps_test.go
+++ b/spinc/cmd/ps_test.go
@@ -1,0 +1,55 @@
+package cmd_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/square/spincycle/proto"
+	"github.com/square/spincycle/spinc/app"
+	"github.com/square/spincycle/spinc/cmd"
+	"github.com/square/spincycle/test/mock"
+)
+
+func TestPs(t *testing.T) {
+	output := &bytes.Buffer{}
+	status := proto.RunningStatus{
+		Jobs: []proto.JobStatus{
+			{
+				RequestId: "b9uvdi8tk9kahl8ppvbg",
+				JobId:     "jid1",
+				Type:      "jobtype",
+				Name:      "jobname",
+				StartedAt: time.Now().Add(-3 * time.Second).UnixNano(),
+				N:         1,
+			},
+		},
+		Requests: map[string]proto.Request{
+			"b9uvdi8tk9kahl8ppvbg": proto.Request{
+				Id:        "b9uvdi8tk9kahl8ppvbg",
+				TotalJobs: 9,
+			},
+		},
+	}
+	rmc := &mock.RMClient{
+		SysStatRunningFunc: func() (proto.RunningStatus, error) {
+			return status, nil
+		},
+	}
+	ctx := app.Context{
+		Out:      output,
+		RMClient: rmc,
+	}
+	ps := cmd.NewPs(ctx)
+	err := ps.Run()
+	if err != nil {
+		t.Errorf("got err '%s', exepcted nil", err)
+	}
+
+	expectOutput := `ID                       N  NJOBS    TIME  JOB
+b9uvdi8tk9kahl8ppvbg     1      9     3.0  jobname
+`
+	if output.String() != expectOutput {
+		t.Errorf("got output:\n%s\nexpected:\n%s\n", output, expectOutput)
+	}
+}


### PR DESCRIPTION
* Fix todo in `chain.Traverser` wrt when/where this call is made: `t.chain.SetJobState(nextJ.Id, proto.STATE_RUNNING)`
* Remove `chain.RunningJob` and enhance and use `proto.JobStatus` instead
* Make `chain/` thread-safe by internalizing and guarding its own `proto.JobChain` and `running`
* Make `chain` implement JSON marshaling interfaces (needed given ^)
* Super basic `spinc/cmd.Pd` test
* Fix `chain. JobIsReady`: return immediately on first `false`, don't search the whole chain
* Privatize some `chain` functions that are only called internally