### PR TITLE
Remove references to old package name

### DIFF
--- a/job-runner/server/server.go
+++ b/job-runner/server/server.go
@@ -9,12 +9,12 @@ import (
 	"github.com/orcaman/concurrent-map"
 
 	"github.com/square/spincycle/config"
+	"github.com/square/spincycle/dev/jobs"
 	"github.com/square/spincycle/job-runner/api"
 	"github.com/square/spincycle/job-runner/app"
 	"github.com/square/spincycle/job-runner/chain"
 	"github.com/square/spincycle/job-runner/runner"
 	"github.com/square/spincycle/job-runner/status"
-	"github.com/square/spincycle/jobs"
 )
 
 // Run runs the Job Runner API in the foreground. It returns when the API stops.

--- a/jobs
+++ b/jobs
@@ -1,1 +1,0 @@
-dev/jobs/

--- a/request-manager/app/app.go
+++ b/request-manager/app/app.go
@@ -15,8 +15,8 @@ import (
 	"github.com/go-sql-driver/mysql"
 
 	"github.com/square/spincycle/config"
+	"github.com/square/spincycle/dev/jobs"
 	jr "github.com/square/spincycle/job-runner"
-	"github.com/square/spincycle/jobs"
 	"github.com/square/spincycle/request-manager/grapher"
 	"github.com/square/spincycle/request-manager/id"
 	"github.com/square/spincycle/util"


### PR DESCRIPTION
The "./jobs" package was moved to "./dev/jobs" in commit c38fdfd1. This
changes package references to use the new name and removes the old
symlink to get rid of the old package name completely.