### PR TITLE
Add placeholder jobs implementation

### DIFF
--- a/dev/run-spincycle
+++ b/dev/run-spincycle
@@ -197,6 +197,15 @@ create_db() {
 }
 
 build() {
+  if [[ ! -L "$REPO_ROOT_DIR/jobs" ]]; then
+    echo "Installing development sandbox jobs..."
+    rm "$REPO_ROOT_DIR/jobs/factory.go"
+    rmdir "$REPO_ROOT_DIR/jobs"
+    ln -s dev/jobs "$REPO_ROOT_DIR/jobs"
+  else
+    echo "Using development sandbox jobs"
+  fi
+
   if [[ ! -x "$RM_BIN" ]] || [[ "$BUILD" ]]; then
     echo "Building request manager..."
     cd "$REPO_ROOT_DIR/request-manager/bin"

--- a/job-runner/server/server.go
+++ b/job-runner/server/server.go
@@ -9,12 +9,12 @@ import (
 	"github.com/orcaman/concurrent-map"
 
 	"github.com/square/spincycle/config"
-	"github.com/square/spincycle/dev/jobs"
 	"github.com/square/spincycle/job-runner/api"
 	"github.com/square/spincycle/job-runner/app"
 	"github.com/square/spincycle/job-runner/chain"
 	"github.com/square/spincycle/job-runner/runner"
 	"github.com/square/spincycle/job-runner/status"
+	"github.com/square/spincycle/jobs"
 )
 
 // Run runs the Job Runner API in the foreground. It returns when the API stops.

--- a/jobs/factory.go
+++ b/jobs/factory.go
@@ -1,0 +1,21 @@
+// Copyright 2018, Square, Inc.
+
+// Package jobs implements all SpinCycle jobs and a factory to create them. This package
+// is intended to be overwritten with a custom jobs package with factory and job
+// implementations that make sense for your domain. For an example jobs package, look at
+// the package github.com/square/spincycle/dev/jobs.
+package jobs
+
+import (
+	"github.com/square/spincycle/job"
+)
+
+// Factory is a package variable referenced from other modules. It is the main entry point
+// to domain-specific jobs. Refer to the job.Factory type for usage documentation.
+var Factory job.Factory = empty{}
+
+type empty struct{}
+
+func (empty) Make(_ job.Id) (job.Job, error) {
+	panic("replace the spincycle jobs package with your own implementation")
+}

--- a/request-manager/app/app.go
+++ b/request-manager/app/app.go
@@ -15,8 +15,8 @@ import (
 	"github.com/go-sql-driver/mysql"
 
 	"github.com/square/spincycle/config"
-	"github.com/square/spincycle/dev/jobs"
 	jr "github.com/square/spincycle/job-runner"
+	"github.com/square/spincycle/jobs"
 	"github.com/square/spincycle/request-manager/grapher"
 	"github.com/square/spincycle/request-manager/id"
 	"github.com/square/spincycle/util"


### PR DESCRIPTION
This commit reverts commit fbb079de in #60.  In that PR, I misunderstood
how the "github.com/square/spincycle/jobs" package was being used.
SpinCycle is designed to have customizable actions, and the way to
customize them is to replace the contents of that package with an
implementation tailored for a domain.  Having the "./jobs" package as a
symlink is supposed to make it easy to replace.  In practice, it breaks
Go vendoring tools.

This commit replaces the symlink with a real "./jobs" package containing
a dummy job factory implementation.  To ensure that it is not
accidentally used in production, the factory panics.  To assist users
and future contributors, the package documents its intended use: to be
replaced with a real implementation.