### PR TITLE
All jobs in a new job chain should be pending

### DIFF
--- a/request-manager/request/manager.go
+++ b/request-manager/request/manager.go
@@ -121,6 +121,7 @@ func (m *manager) Create(reqParams proto.CreateRequestParams) (proto.Request, er
 			RetryWait:     node.RetryWait,
 			SequenceId:    node.SequenceId,
 			SequenceRetry: node.SequenceRetry,
+			State:         proto.STATE_PENDING,
 		}
 		jc.Jobs[jobId] = job
 	}

--- a/request-manager/request/manager_test.go
+++ b/request-manager/request/manager_test.go
@@ -183,6 +183,12 @@ func TestCreate(t *testing.T) {
 		}
 	*/
 
+	for _, job := range actualJobChain.Jobs {
+		if job.State != proto.STATE_PENDING {
+			t.Errorf("job %s has state %s, expected all jobs to be STATE_PENDING", job.Id, proto.StateName[job.State])
+		}
+	}
+
 	expectedReq := proto.Request{
 		Id:        actualReq.Id, // no other way of getting this from outside the package
 		Type:      reqParams.Type,


### PR DESCRIPTION
When the RM creates a new job chain, set the state of all the new jobs to Pending.