### PR TITLE
Request ACLs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -134,8 +134,13 @@ type TLS struct {
 
 // Auth configuration.
 type Auth struct {
-	// Callers with one of these roles are request admins (allowed all ops) for all requests.
+	// Callers with one of these roles are admins (allowed all ops) for all requests.
 	AdminRoles []string `yaml:"admin_roles"`
+
+	// Strict requires all requests to have ACLs, else callers are denied unless
+	// they have an admin role. Strict is disabled by default which, with the default
+	// auth plugin, allows all callers (no auth).
+	Strict bool `yaml:"strict"`
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,10 @@ type RequestManager struct {
 	// The directory that holds all of the grapher spec files. This dir
 	// should not contain anything other than spec files.
 	SpecFileDir string `yaml:"spec_file_dir"`
+
+	// Auth specifies auth plugin options. If a user-provide auth plugin is not
+	// given, these options are ignored and all users and apps have admin access.
+	Auth Auth `yaml:"auth"`
 }
 
 // The config used by the Job Runner. This is read from in
@@ -126,6 +130,12 @@ type TLS struct {
 
 	// The CA file to use.
 	CAFile string `yaml:"ca_file"`
+}
+
+// Auth configuration.
+type Auth struct {
+	// Callers with one of these roles are request admins (allowed all ops) for all requests.
+	AdminRoles []string `yaml:"admin_roles"`
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proto/const.go
+++ b/proto/const.go
@@ -48,3 +48,8 @@ var StateValue = map[string]byte{
 	"STOPPED":   STATE_STOPPED,
 	"SUSPENDED": STATE_SUSPENDED,
 }
+
+const (
+	REQUEST_OP_START = "start"
+	REQUEST_OP_STOP  = "stop"
+)

--- a/request-manager/api/api.go
+++ b/request-manager/api/api.go
@@ -80,7 +80,7 @@ func NewAPI(appCtx app.Context) *API {
 	// @todo: ignore OPTION requests?
 	api.echo.Use((func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			caller, err := appCtx.Plugins.Auth.Authenticate(c.Request())
+			caller, err := appCtx.Auth.Authenticate(c.Request())
 			if err != nil {
 				return echo.NewHTTPError(http.StatusUnauthorized, err.Error())
 			}

--- a/request-manager/api/api_test.go
+++ b/request-manager/api/api_test.go
@@ -35,6 +35,9 @@ func setup(rm *mock.RequestManager, jls *mock.JLStore) {
 	appCtx.RM = rm
 	appCtx.JLS = jls
 	appCtx.Status = &mock.RMStatus{}
+	appCtx.Hooks.SetUsername = func(*http.Request) (string, error) {
+		return "admin", nil
+	}
 	appCtx.Plugins.Auth = mockAuth
 	appCtx.Auth = auth.NewManager(mockAuth, map[string][]auth.ACL{}, []string{"test"}, false)
 	server = httptest.NewServer(api.NewAPI(appCtx))

--- a/request-manager/api/api_test.go
+++ b/request-manager/api/api_test.go
@@ -21,7 +21,7 @@ import (
 
 var server *httptest.Server
 
-var mockAuth = mock.Auth{
+var mockAuth = mock.AuthPlugin{
 	AuthenticateFunc: func(*http.Request) (auth.Caller, error) {
 		return auth.Caller{
 			Name:  "test",
@@ -507,7 +507,7 @@ func TestAuth(t *testing.T) {
 		}
 	}
 	ctx := app.Defaults()
-	ctx.Plugins.Auth = mock.Auth{
+	ctx.Plugins.Auth = mock.AuthPlugin{
 		AuthenticateFunc: func(*http.Request) (auth.Caller, error) {
 			authenticateCalled = true
 			return caller, authenErr

--- a/request-manager/api/api_test.go
+++ b/request-manager/api/api_test.go
@@ -21,12 +21,22 @@ import (
 
 var server *httptest.Server
 
+var mockAuth = mock.Auth{
+	AuthenticateFunc: func(*http.Request) (auth.Caller, error) {
+		return auth.Caller{
+			Name:  "test",
+			Roles: []string{"test"},
+		}, nil
+	},
+}
+
 func setup(rm *mock.RequestManager, jls *mock.JLStore) {
 	appCtx := app.Defaults()
 	appCtx.RM = rm
 	appCtx.JLS = jls
 	appCtx.Status = &mock.RMStatus{}
-	appCtx.Auth = auth.NewManager(auth.AllowAll{}, map[string][]auth.ACL{}, []string{"all"}, false)
+	appCtx.Plugins.Auth = mockAuth
+	appCtx.Auth = auth.NewManager(mockAuth, map[string][]auth.ACL{}, []string{"test"}, false)
 	server = httptest.NewServer(api.NewAPI(appCtx))
 }
 
@@ -489,7 +499,7 @@ func TestAuth(t *testing.T) {
 		authOp = ""
 		authReq = proto.Request{}
 		caller = auth.Caller{
-			User:  "dn",
+			Name:  "dn",
 			Roles: []string{"role1", "role2"}, // matches roles in auth-001.yaml (see below)
 		}
 	}

--- a/request-manager/app/app.go
+++ b/request-manager/app/app.go
@@ -61,8 +61,18 @@ type Factories struct {
 // the LoadConfig hook allows the user to load and parse the config file, completely
 // overriding the built-in code.
 type Hooks struct {
-	LoadConfig  func(Context) (config.RequestManager, error)
-	LoadSpecs   func(Context) (grapher.Config, error)
+	// LoadConfig loads the Request Manager config file. This hook overrides
+	// the default function. Spin Cycle fails to start if it returns an error.
+	LoadConfig func(Context) (config.RequestManager, error)
+
+	// LoadSpecs loads the request specification files (specs). This hook overrides
+	// the default function. Spin Cycle fails to start if it returns an error.
+	LoadSpecs func(Context) (grapher.Config, error)
+
+	// SetUsername sets proto.Request.User. The auth.Plugin.Authenticate method is
+	// called first which sets the username to Caller.Name. This hook is called after
+	// and overrides the username. The request fails and returns HTTP 500 if it
+	// returns an error.
 	SetUsername func(*http.Request) (string, error)
 }
 
@@ -92,9 +102,6 @@ func Defaults() Context {
 		},
 		Hooks: Hooks{
 			LoadConfig: LoadConfig,
-			SetUsername: (func(ireq *http.Request) (string, error) {
-				return "admin", nil
-			}),
 		},
 		Plugins: Plugins{
 			Auth: auth.AllowAll{},

--- a/request-manager/app/app.go
+++ b/request-manager/app/app.go
@@ -115,7 +115,7 @@ func LoadConfig(ctx Context) (config.RequestManager, error) {
 		case "staging":
 			cfgFile = "config/staging.yaml"
 		case "production":
-			cfgFile = "config/staging.yaml"
+			cfgFile = "config/production.yaml"
 		default:
 			cfgFile = "config/development.yaml"
 		}

--- a/request-manager/auth/auth.go
+++ b/request-manager/auth/auth.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/square/spincycle/proto"
+)
+
+// Caller represents an app or user making a request. Callers are determined by
+// the auth plugin, if any.
+type Caller struct {
+	App   string   // caller is app, or
+	User  string   // caller is human (mutually exclusive)
+	Roles []string // for User
+}
+
+// Auth represents the auth plugin interface. If given, the methods are called
+// for every request to authenticate the calling app or user, then authorize it
+// for the request and op (see proto.REQUEST_OP.*).
+type Auth interface {
+	// Authenticate caller from HTTP request.
+	Authenticate(*http.Request) (Caller, error)
+
+	// Authorize the created request with user-provided args.
+	Authorize(c Caller, op string, req proto.Request) error
+}
+
+// AllowAll is the default auth plugin which allows all apps and users.
+type AllowAll struct{}
+
+func (a AllowAll) Authenticate(*http.Request) (Caller, error) {
+	return Caller{
+		App:  "all",
+		User: "everyone",
+	}, nil
+}
+
+func (a AllowAll) Authorize(c Caller, op string, req proto.Request) error {
+	return nil
+}

--- a/request-manager/auth/auth.go
+++ b/request-manager/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/square/spincycle/proto"
@@ -14,10 +15,8 @@ type Caller struct {
 	Roles []string // for User
 }
 
-// Auth represents the auth plugin interface. If given, the methods are called
-// for every request to authenticate the calling app or user, then authorize it
-// for the request and op (see proto.REQUEST_OP.*).
-type Auth interface {
+// Plugin represents the auth plugin. Every request is authenticated and authorized.
+type Plugin interface {
 	// Authenticate caller from HTTP request.
 	Authenticate(*http.Request) (Caller, error)
 
@@ -25,16 +24,125 @@ type Auth interface {
 	Authorize(c Caller, op string, req proto.Request) error
 }
 
-// AllowAll is the default auth plugin which allows all apps and users.
+// AllowAll is the default auth plugin which allows all callers and requests (no auth).
 type AllowAll struct{}
 
 func (a AllowAll) Authenticate(*http.Request) (Caller, error) {
 	return Caller{
-		App:  "all",
-		User: "everyone",
+		App:   "all",
+		User:  "all",
+		Roles: []string{"all"},
 	}, nil
 }
 
 func (a AllowAll) Authorize(c Caller, op string, req proto.Request) error {
 	return nil
+}
+
+// ACL represents one role-based ACL entry. This ACL is the same as grapher.ACL.
+// The latter is mapped to the former in Server.Boot to keep the two packages
+// decoupled, i.e. decouple spec syntax from internal data structures.
+type ACL struct {
+	Role  string   // user-defined role
+	Admin bool     // all ops allowed if true
+	Ops   []string // proto.REQUEST_OP_*
+}
+
+// Manager provides request authorization using the auth plugin and a list of ACLs.
+type Manager struct {
+	plugin     Plugin
+	acls       map[string][]ACL // request-name (type) -> acl: (if any)
+	adminRoles []string
+	strict     bool
+}
+
+func NewManager(plugin Plugin, acls map[string][]ACL, adminRoles []string, strict bool) Manager {
+	return Manager{
+		plugin:     plugin,
+		acls:       acls,
+		adminRoles: adminRoles,
+		strict:     strict,
+	}
+}
+
+// Authorize authorizes the request based on its ACLs, if any. First, this checks
+// the caller's roles (provided by the auth plugin Authenticate method) against
+// the request ACL roles. If there's a match which allows the request, it calls
+// the auth plugin Authorize method to let it authorize the request based on request
+// args. For example, the caller might not be allowed to run the request on certain
+// hosts. If authorized, returns nil; else, returns an error.
+func (m Manager) Authorize(caller Caller, op string, req proto.Request) error {
+	// Always allow admins, nothing more to check
+	if m.isAdmin(caller) {
+		return nil // allow
+	}
+
+	// Get ACLs for this request
+	acls, ok := m.acls[req.Type]
+	if !ok {
+		return fmt.Errorf("denied: request %s is not defined", req.Type) // shouldn't happen
+	}
+
+	// If no request ACLs and strict, deny. Else (default), allow.
+	if len(acls) == 0 {
+		if m.strict {
+			return fmt.Errorf("denied: request %s has no ACLs and strict auth is enabled", req.Type)
+		}
+		return nil // not strict, allow
+	}
+
+	// Pre-authorize based on request ACL roles and ops. For every request ACL,
+	// check if caller has role and role grants the op. Allow on first match.
+	rolesMatch := false // at least one role matches
+	opMatch := false    // at least one role + op matches
+REQUEST_ACLS:
+	for _, acl := range acls {
+		for _, crole := range caller.Roles {
+			// Does caller have this role?
+			if crole != acl.Role {
+				continue // no
+			}
+			rolesMatch = true // yes
+
+			for _, aclop := range acl.Ops {
+				// Does role grant caller the op?
+				if aclop != op {
+					continue // no
+				}
+				opMatch = true // yes
+				break REQUEST_ACLS
+			}
+		}
+	}
+	if !rolesMatch {
+		reqRoles := make([]string, len(acls))
+		for i, acl := range acls {
+			reqRoles[i] = acl.Role
+		}
+		return fmt.Errorf("denied: no caller role matches %s ACL: caller has %v, %s requires one of %v", req.Type, caller.Roles, req.Type, reqRoles)
+	}
+	if !opMatch {
+		return fmt.Errorf("denied: no matching caller role granted %s op for request %s", op, req.Type)
+	}
+
+	// Plugin authorize based on op and request args
+	if err := m.plugin.Authorize(caller, op, req); err != nil {
+		return fmt.Errorf("denied by auth plugin Authorize: %s", err)
+	}
+
+	return nil // allow
+}
+
+func (m Manager) isAdmin(caller Caller) bool {
+	if len(m.adminRoles) == 0 {
+		return false
+	}
+	for _, arole := range m.adminRoles {
+		for _, crole := range caller.Roles {
+			if crole == arole {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/request-manager/auth/auth.go
+++ b/request-manager/auth/auth.go
@@ -104,6 +104,12 @@ REQUEST_ACLS:
 			}
 			rolesMatch = true // yes
 
+			// Is it an admin role? If yes, then allow all ops.
+			if acl.Admin {
+				opMatch = true // yes
+				break REQUEST_ACLS
+			}
+
 			for _, aclop := range acl.Ops {
 				// Does role grant caller the op?
 				if aclop != op {

--- a/request-manager/auth/auth.go
+++ b/request-manager/auth/auth.go
@@ -2,7 +2,7 @@
 
 // Package auth provides request authentication and authorization. By default,
 // there is no auth; all callers and requests are allowed. The Plugin interface
-// allows user-defined auth in combination with user-defined request sepc ACLs.
+// allows user-defined auth in combination with user-defined request spec ACLs.
 // See docs/auth.md.
 package auth
 
@@ -82,7 +82,7 @@ type ACL struct {
 	Ops []string
 }
 
-// Manager provides pre- and post-authorization. It matches caller ACLs to request
+// Manager provides pre- and post-authorization. It matches caller roles to request
 // ACLs, and calls Plugin.Authorize when there is a match. It also handles admin
 // roles and strict auth logic. Authentication is not handled by the Manager; that
 // happens in api.API middleware.
@@ -109,7 +109,7 @@ func NewManager(plugin Plugin, acls map[string][]ACL, adminRoles []string, stric
 // post-authorization. If it returns nil, the request is allowed.
 //
 // If the request has no ACLs and the caller does not have an admin role, strict
-// mode determines the result: allow if disabled (no ACLs = allow allow), deny
+// mode determines the result: allow if disabled (no ACLs = allow all), deny
 // if enabled (no ACLs = deny all non-admins).
 //
 // Any return error denies the request (HTTP 401), and the error message explains why.

--- a/request-manager/auth/auth.go
+++ b/request-manager/auth/auth.go
@@ -114,7 +114,8 @@ func NewManager(plugin Plugin, acls map[string][]ACL, adminRoles []string, stric
 //
 // Any return error denies the request (HTTP 401), and the error message explains why.
 func (m Manager) Authorize(caller Caller, op string, req proto.Request) error {
-	// Always allow admins, nothing more to check
+	// Always allow admins, nothing more to check. This is global admin_roles from config:
+	// role which are admins for all requests regardless of request-specific ACLs.
 	if m.isAdmin(caller) {
 		return nil // allow
 	}
@@ -146,7 +147,8 @@ REQUEST_ACLS:
 			}
 			rolesMatch = true // yes
 
-			// Is it an admin role? If yes, then allow all ops.
+			// Is it an admin role? If yes, then allow all ops. This is
+			// request-specific admin role, not global admin_roles from config.
 			if acl.Admin {
 				opMatch = true // yes
 				break REQUEST_ACLS

--- a/request-manager/auth/auth_test.go
+++ b/request-manager/auth/auth_test.go
@@ -93,6 +93,19 @@ func TestManagerWithACLs(t *testing.T) {
 		t.Errorf("auth plugin Authorize not called, expected it to be called")
 	}
 
+	// Admin role match allowed: role1 is admin role, so even though op is fake,
+	// doesn't matter. Admin roles can do anything wrt pre-auth. The auth plugin
+	// can still deny it later.
+	authCalled = false
+	caller.Roles = []string{"role1"}
+	err = m.Authorize(caller, "fake", req)
+	if err != nil {
+		t.Errorf("not allowed (%s), expected Authorize to return nil", err)
+	}
+	if authCalled == false {
+		t.Errorf("auth plugin Authorize not called, expected it to be called")
+	}
+
 	// If auth plugin Authorize denies, manager denies
 	authCalled = false
 	authErr = fmt.Errorf("fake auth error")

--- a/request-manager/auth/auth_test.go
+++ b/request-manager/auth/auth_test.go
@@ -35,7 +35,7 @@ func TestManagerWithACLs(t *testing.T) {
 	m := auth.NewManager(plugin, acls, adminRoles, true)
 
 	caller := auth.Caller{
-		User:  "dn",
+		Name:  "dn",
 		Roles: []string{"dev"}, // no admin role
 	}
 	req := proto.Request{
@@ -145,7 +145,7 @@ func TestManagerNoACLs(t *testing.T) {
 	m := auth.NewManager(plugin, acls, nil, true) // true = STRICT MODE
 
 	caller := auth.Caller{
-		User:  "dn",
+		Name:  "dn",
 		Roles: []string{"dev"}, // no admin role
 	}
 	req := proto.Request{

--- a/request-manager/auth/auth_test.go
+++ b/request-manager/auth/auth_test.go
@@ -1,0 +1,178 @@
+package auth_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/square/spincycle/proto"
+	"github.com/square/spincycle/request-manager/auth"
+	"github.com/square/spincycle/test/mock"
+)
+
+func TestManagerWithACLs(t *testing.T) {
+	acls := map[string][]auth.ACL{
+		"req1": []auth.ACL{
+			{
+				Role:  "role1",
+				Admin: true,
+			},
+			{
+				Role: "role2",
+				Ops:  []string{"start", "stop"},
+			},
+		},
+	}
+
+	authCalled := false
+	var authErr error
+	plugin := mock.Auth{
+		AuthorizeFunc: func(caller auth.Caller, op string, req proto.Request) error {
+			authCalled = true
+			return authErr
+		},
+	}
+	adminRoles := []string{"finch"}
+	m := auth.NewManager(plugin, acls, adminRoles, true)
+
+	caller := auth.Caller{
+		User:  "dn",
+		Roles: []string{"dev"}, // no admin role
+	}
+	req := proto.Request{
+		Id:   "abc",
+		Type: "req1",
+	}
+
+	// Should be denied (return error) because caller doesn't have an admin role
+	// and or any matching role
+	authCalled = false
+	err := m.Authorize(caller, proto.REQUEST_OP_START, req)
+	t.Log(err)
+	if err == nil {
+		t.Errorf("allowed, expected Authorize to return err")
+	}
+	if authCalled == true {
+		t.Errorf("auth plugin Authorize called, expected it NOT to be called")
+	}
+
+	// Should be denied (return error) because caller has role (role2) but it
+	// doens't grant the bogus op, "foo".
+	authCalled = false
+	caller.Roles = []string{"role2"}
+	err = m.Authorize(caller, "foo", req)
+	t.Log(err)
+	if err == nil {
+		t.Errorf("allowed, expected Authorize to return err")
+	}
+	if authCalled == true {
+		t.Errorf("auth plugin Authorize called, expected it NOT to be called")
+	}
+
+	// Set admin role to caller and it should be allowed even though the request
+	// ACL has no explicit role for the admin role. It's allowed because caller
+	// has the admin role. It doesn't even check Authorize plugin method.
+	authCalled = false
+	caller.Roles = adminRoles
+	err = m.Authorize(caller, proto.REQUEST_OP_START, req)
+	if err != nil {
+		t.Errorf("not allowed (%s), expected Authorize to return nil", err)
+	}
+	if authCalled == true {
+		t.Errorf("auth plugin Authorize called, expected it NOT to be called")
+	}
+
+	// Normal match allowed: req has role2 with op "start". When pre-authorization
+	// passes, then the plugin Authorize method is called.
+	authCalled = false
+	caller.Roles = []string{"role2"}
+	err = m.Authorize(caller, proto.REQUEST_OP_START, req)
+	if err != nil {
+		t.Errorf("not allowed (%s), expected Authorize to return nil", err)
+	}
+	if authCalled == false {
+		t.Errorf("auth plugin Authorize not called, expected it to be called")
+	}
+
+	// If auth plugin Authorize denies, manager denies
+	authCalled = false
+	authErr = fmt.Errorf("fake auth error")
+	err = m.Authorize(caller, proto.REQUEST_OP_START, req)
+	if err == nil {
+		t.Errorf("allowed, expected Authorize to return err")
+	}
+	if authCalled == false {
+		t.Errorf("auth plugin Authorize not called, expected it to be called")
+	}
+
+	// Don't allow nonexistent requests
+	authCalled = false
+	err = m.Authorize(caller, "foo", proto.Request{Type: "foo"})
+	t.Log(err)
+	if err == nil {
+		t.Errorf("allowed, expected Authorize to return err")
+	}
+	if authCalled == true {
+		t.Errorf("auth plugin Authorize called, expected it NOT to be called")
+	}
+}
+
+func TestManagerNoACLs(t *testing.T) {
+	acls := map[string][]auth.ACL{
+		"req1": []auth.ACL{},
+	}
+
+	authCalled := false
+	var authErr error
+	plugin := mock.Auth{
+		AuthorizeFunc: func(caller auth.Caller, op string, req proto.Request) error {
+			authCalled = true
+			return authErr
+		},
+	}
+	m := auth.NewManager(plugin, acls, nil, true) // true = STRICT MODE
+
+	caller := auth.Caller{
+		User:  "dn",
+		Roles: []string{"dev"}, // no admin role
+	}
+	req := proto.Request{
+		Id:   "abc",
+		Type: "req1",
+	}
+
+	// Should be denied (return error) because no ACLs + strict mode
+	authCalled = false
+	err := m.Authorize(caller, proto.REQUEST_OP_START, req)
+	t.Log(err)
+	if err == nil {
+		t.Errorf("allowed, expected Authorize to return err")
+	}
+	if authCalled == true {
+		t.Errorf("auth plugin Authorize called, expected it NOT to be called")
+	}
+
+	// But turn strict mode off and no ACLs = allow all
+	m = auth.NewManager(plugin, acls, nil, false) // false = strict mode off
+	authCalled = false
+	err = m.Authorize(caller, proto.REQUEST_OP_START, req)
+	if err != nil {
+		t.Errorf("not allowed (%s), expected Authorize to return nil", err)
+	}
+	if authCalled == true {
+		t.Errorf("auth plugin Authorize called, expected it NOT to be called")
+	}
+}
+
+func TestAllowAll(t *testing.T) {
+	all := auth.AllowAll{}
+
+	caller, err := all.Authenticate(nil)
+	if err != nil {
+		t.Errorf("not allowed (%s), expected Authorize to return nil", err)
+	}
+
+	err = all.Authorize(caller, "", proto.Request{})
+	if err != nil {
+		t.Errorf("not allowed (%s), expected Authorize to return nil", err)
+	}
+}

--- a/request-manager/bin/main.go
+++ b/request-manager/bin/main.go
@@ -10,6 +10,10 @@ import (
 )
 
 func main() {
-	err := server.Run(app.Defaults())
+	s := server.NewServer(app.Defaults())
+	if err := s.Boot(); err != nil {
+		log.Fatalf("Error starting Request Manager: %s", err)
+	}
+	err := s.Run()
 	log.Fatalf("Request Manager stopped: %s", err)
 }

--- a/request-manager/grapher/grapher.go
+++ b/request-manager/grapher/grapher.go
@@ -30,7 +30,7 @@ type Grapher struct {
 // An id generator must also be provided (used for generating ids for nodes).
 //
 // A new Grapher should be made for every request.
-func NewGrapher(nf job.Factory, cfg *Config, idgen id.Generator) *Grapher {
+func NewGrapher(nf job.Factory, cfg Config, idgen id.Generator) *Grapher {
 	o := &Grapher{
 		JobFactory:   nf,
 		AllSequences: cfg.Sequences,
@@ -48,12 +48,12 @@ type GrapherFactory interface {
 // grapherFactory implements the GrapherFactory interface.
 type grapherFactory struct {
 	jf     job.Factory
-	config *Config
+	config Config
 	idf    id.GeneratorFactory
 }
 
 // NewGrapherFactory creates a GrapherFactory.
-func NewGrapherFactory(jf job.Factory, cfg *Config, idf id.GeneratorFactory) GrapherFactory {
+func NewGrapherFactory(jf job.Factory, cfg Config, idf id.GeneratorFactory) GrapherFactory {
 	return &grapherFactory{
 		jf:     jf,
 		config: cfg,

--- a/request-manager/grapher/grapher_test.go
+++ b/request-manager/grapher/grapher_test.go
@@ -1312,7 +1312,7 @@ func TestAuthSpec(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expect := &Config{
+	expect := Config{
 		Sequences: map[string]*SequenceSpec{
 			"req1": &SequenceSpec{
 				Name:    "req1",

--- a/request-manager/grapher/grapher_test.go
+++ b/request-manager/grapher/grapher_test.go
@@ -1305,3 +1305,48 @@ func TestBadEach001(t *testing.T) {
 		t.Error("err is nil, expected an error")
 	}
 }
+
+func TestAuthSpec(t *testing.T) {
+	// Test that the acl: part of a request is parsed properly
+	got, err := ReadConfig("../test/specs/auth-001.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := &Config{
+		Sequences: map[string]*SequenceSpec{
+			"req1": &SequenceSpec{
+				Name:    "req1",
+				Request: true,
+				Args: SequenceArgs{
+					Required: []*ArgSpec{
+						{
+							Name: "arg1",
+							Desc: "required arg 1",
+						},
+					},
+				},
+				ACL: []ACL{
+					{
+						Role:  "role1",
+						Admin: true,
+					},
+					{
+						Role:  "role2",
+						Admin: false,
+						Ops:   []string{"start", "stop"},
+					},
+				},
+				Nodes: map[string]*NodeSpec{
+					"node1": &NodeSpec{
+						Name:     "node1",
+						Category: "job",
+						NodeType: "job1type",
+					},
+				},
+			},
+		},
+	}
+	if diff := deep.Equal(got, expect); diff != nil {
+		t.Error(diff)
+	}
+}

--- a/request-manager/grapher/spec.go
+++ b/request-manager/grapher/spec.go
@@ -3,6 +3,7 @@
 package grapher
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"gopkg.in/yaml.v2"
@@ -32,11 +33,12 @@ type NodeArg struct {
 // SequenceSpec defines the structure expected from the config yaml file to
 // define each sequence
 type SequenceSpec struct {
-	Name    string               `yaml:"name"`  // name of the sequence
-	Args    SequenceArgs         `yaml:"args"`  // arguments to the sequence
-	Nodes   map[string]*NodeSpec `yaml:"nodes"` // list of nodes that are a part of the sequence
-	Retry   uint                 `yaml:"retry"` // the number of times to retry the sequence if it fails
-	Request bool                 // whether or not the sequence spec is a user request
+	Name    string               `yaml:"name"`    // name of the sequence
+	Args    SequenceArgs         `yaml:"args"`    // arguments to the sequence
+	Nodes   map[string]*NodeSpec `yaml:"nodes"`   // list of nodes that are a part of the sequence
+	Retry   uint                 `yaml:"retry"`   // the number of times to retry the sequence if it fails
+	Request bool                 `yaml:"request"` // whether or not the sequence spec is a user request
+	ACL     []ACL                `yaml:"acl"`     // allowed caller roles (optional)
 }
 
 // SequenceArgs defines the structure expected from the config file to define
@@ -56,6 +58,16 @@ type ArgSpec struct {
 	Name    string `yaml:"name"`
 	Desc    string `yaml:"desc"`
 	Default string `yaml:"default"`
+}
+
+// ACL represents one role-based ACL entry. Every auth.Caller (from the
+// user-provided auth plugin Authenticate method) is authorized with a matching
+// ACL, else the request is denied with HTTP 401 unauthorized. Roles are
+// user-defined. If Admin is true, Ops cannot be set.
+type ACL struct {
+	Role  string   `yaml:"role"`  // user-defined role
+	Admin bool     `yaml:"admin"` // all ops allowed if true
+	Ops   []string `yaml:"ops"`   // proto.REQUEST_OP_*
 }
 
 // All Sequences in the yaml. Also contains the user defined no-op job.
@@ -81,6 +93,21 @@ func ReadConfig(configFile string) (*Config, error) {
 		sequence.Name = sequenceName
 		for nodeName, node := range sequence.Nodes {
 			node.Name = nodeName
+		}
+
+		// Validate ACLs, if any
+		seen := map[string]bool{}
+		for _, acl := range sequence.ACL {
+			if acl.Admin && len(acl.Ops) != 0 {
+				return nil, fmt.Errorf("invalid user ACL for %s in %s: admin=true and ops are mutually exclusive; set admin=false or remove ops", sequenceName, configFile)
+			}
+			if acl.Role == "" {
+				return nil, fmt.Errorf("invalid user ACL for %s in %s: role is not set (empty string); it must be set", sequenceName, configFile)
+			}
+			if seen[acl.Role] {
+				return nil, fmt.Errorf("duplicate user ACL for %s in %s: role=%s", sequenceName, configFile, acl.Role)
+			}
+			seen[acl.Role] = true
 		}
 	}
 

--- a/request-manager/grapher/spec.go
+++ b/request-manager/grapher/spec.go
@@ -78,15 +78,15 @@ type Config struct {
 // ReadConfig will read from configFile and return a Config that the user
 // can then use for NewGrapher(). configFile is expected to be in the yaml
 // format specified.
-func ReadConfig(configFile string) (*Config, error) {
+func ReadConfig(configFile string) (Config, error) {
+	var cfg Config
 	sequenceData, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		return nil, err
+		return cfg, err
 	}
-	cfg := &Config{}
-	err = yaml.Unmarshal(sequenceData, cfg)
+	err = yaml.Unmarshal(sequenceData, &cfg)
 	if err != nil {
-		return nil, err
+		return cfg, err
 	}
 
 	for sequenceName, sequence := range cfg.Sequences {
@@ -99,13 +99,13 @@ func ReadConfig(configFile string) (*Config, error) {
 		seen := map[string]bool{}
 		for _, acl := range sequence.ACL {
 			if acl.Admin && len(acl.Ops) != 0 {
-				return nil, fmt.Errorf("invalid user ACL for %s in %s: admin=true and ops are mutually exclusive; set admin=false or remove ops", sequenceName, configFile)
+				return cfg, fmt.Errorf("invalid user ACL for %s in %s: admin=true and ops are mutually exclusive; set admin=false or remove ops", sequenceName, configFile)
 			}
 			if acl.Role == "" {
-				return nil, fmt.Errorf("invalid user ACL for %s in %s: role is not set (empty string); it must be set", sequenceName, configFile)
+				return cfg, fmt.Errorf("invalid user ACL for %s in %s: role is not set (empty string); it must be set", sequenceName, configFile)
 			}
 			if seen[acl.Role] {
-				return nil, fmt.Errorf("duplicate user ACL for %s in %s: role=%s", sequenceName, configFile, acl.Role)
+				return cfg, fmt.Errorf("duplicate user ACL for %s in %s: role=%s", sequenceName, configFile, acl.Role)
 			}
 			seen[acl.Role] = true
 		}

--- a/request-manager/test/specs/auth-001.yaml
+++ b/request-manager/test/specs/auth-001.yaml
@@ -1,0 +1,16 @@
+sequences:
+  req1:
+    args:
+      required:
+        - name: arg1
+          desc: "required arg 1"
+    request: true
+    acl:
+      - role: "role1"
+        admin: true
+      - role: "role2"
+        ops:  [start,stop]
+    nodes:
+      node1:
+        category: job
+        type: job1type

--- a/test/mock/request.go
+++ b/test/mock/request.go
@@ -4,8 +4,10 @@ package mock
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/square/spincycle/proto"
+	"github.com/square/spincycle/request-manager/auth"
 )
 
 var (
@@ -85,4 +87,25 @@ func (r *RequestManager) JobChain(reqId string) (proto.JobChain, error) {
 		return r.JobChainFunc(reqId)
 	}
 	return proto.JobChain{}, nil
+}
+
+// --------------------------------------------------------------------------
+
+type Auth struct {
+	AuthenticateFunc func(*http.Request) (auth.Caller, error)
+	AuthorizeFunc    func(c auth.Caller, op string, req proto.Request) error
+}
+
+func (a Auth) Authenticate(req *http.Request) (auth.Caller, error) {
+	if a.AuthenticateFunc != nil {
+		return a.AuthenticateFunc(req)
+	}
+	return auth.Caller{}, nil
+}
+
+func (a Auth) Authorize(c auth.Caller, op string, req proto.Request) error {
+	if a.AuthorizeFunc != nil {
+		return a.AuthorizeFunc(c, op, req)
+	}
+	return nil
 }

--- a/test/mock/request.go
+++ b/test/mock/request.go
@@ -91,19 +91,19 @@ func (r *RequestManager) JobChain(reqId string) (proto.JobChain, error) {
 
 // --------------------------------------------------------------------------
 
-type Auth struct {
+type AuthPlugin struct {
 	AuthenticateFunc func(*http.Request) (auth.Caller, error)
 	AuthorizeFunc    func(c auth.Caller, op string, req proto.Request) error
 }
 
-func (a Auth) Authenticate(req *http.Request) (auth.Caller, error) {
+func (a AuthPlugin) Authenticate(req *http.Request) (auth.Caller, error) {
 	if a.AuthenticateFunc != nil {
 		return a.AuthenticateFunc(req)
 	}
 	return auth.Caller{}, nil
 }
 
-func (a Auth) Authorize(c auth.Caller, op string, req proto.Request) error {
+func (a AuthPlugin) Authorize(c auth.Caller, op string, req proto.Request) error {
 	if a.AuthorizeFunc != nil {
 		return a.AuthorizeFunc(c, op, req)
 	}


### PR DESCRIPTION
* Add request ACLs: auth pkg and grapher spec changes
* Add `Auth` section to config
* Refactor and document server/
* Expand app.Context and document
* Rename grapher "config" to "specs" in some places ("specs" is the normal term)
* Simplify `api.NewAPI`
* Set `Request.User` from auth plugin then override with `SetUsername` hook if defined
* Document hooks
* Remove default `SetUsername` hook (that set user = "admin")