### PR TITLE
make API run + shutdown configurable

### DIFF
--- a/job-runner/api/api_test.go
+++ b/job-runner/api/api_test.go
@@ -29,7 +29,15 @@ var (
 func setup(traverserFactory *mock.TraverserFactory) {
 	traverserRepo = cmap.New()
 	shutdownChan = make(chan struct{})
-	api := api.NewAPI(app.Defaults(), traverserFactory, traverserRepo, &mock.JRStatus{}, shutdownChan)
+	appCtx := app.Defaults()
+	apiCfg := api.Config{
+		AppCtx:           appCtx,
+		TraverserFactory: traverserFactory,
+		TraverserRepo:    traverserRepo,
+		StatusManager:    &mock.JRStatus{},
+		ShutdownChan:     shutdownChan,
+	}
+	api := api.NewAPI(apiCfg)
 	server = httptest.NewServer(api)
 }
 

--- a/job-runner/app/app.go
+++ b/job-runner/app/app.go
@@ -30,6 +30,16 @@ type Hooks struct {
 	LoadConfig  func(Context) (config.JobRunner, error)
 	Auth        func(*http.Request) (bool, error)
 	SetUsername func(*http.Request) (string, error)
+
+	// RunAPI runs the Job Runner API. It should block until the API is stopped
+	// via a call to StopAPI. If this hook is provided, it is called instead of
+	// api.Run, and StopAPI must be provided as well.
+	RunAPI func() error
+
+	// StopAPI stops running the Job Runner API. It's called when the server is
+	// stopped, and it should cause RunAPI to return. If this hook is provided, it
+	// is called instead of api.Stop, and RunAPI must be provided as well.
+	StopAPI func() error
 }
 
 func Defaults() Context {

--- a/job-runner/bin/main.go
+++ b/job-runner/bin/main.go
@@ -11,6 +11,9 @@ import (
 
 func main() {
 	s := server.NewServer(app.Defaults())
-	err := s.Run()
+	if err := s.Boot(); err != nil {
+		log.Fatalf("Error starting Job Runner: %s", err)
+	}
+	err := s.Run(true)
 	log.Fatalf("Job Runner stopped: %s", err)
 }

--- a/job-runner/server/server.go
+++ b/job-runner/server/server.go
@@ -48,10 +48,10 @@ func NewServer(appCtx app.Context) *Server {
 // hook has been provided, it will be called to run the API instead of the default
 // api.Run.
 //
-// If autoShutdown = true, the server will listen for TERM and INT signals from the
-// OS and call Stop to shut itself down when those signals are received. Else, the \
+// If stopOnSignal = true, the server will listen for TERM and INT signals from the
+// OS and call Stop to shut itself down when those signals are received. Else, the
 // caller must call Stop to shut down the server.
-func (s *Server) Run(autoShutdown bool) error {
+func (s *Server) Run(stopOnSignal bool) error {
 	if s.api == nil {
 		panic("Server.Run called before Server.Boot")
 	}
@@ -59,9 +59,9 @@ func (s *Server) Run(autoShutdown bool) error {
 		return fmt.Errorf("server stopped")
 	}
 
-	// If autoShutdown = true, watch for TERM + INT signals from the OS and shut
+	// If stopOnSignal = true, watch for TERM + INT signals from the OS and shut
 	// down the Job Runner when we receive them.
-	if autoShutdown {
+	if stopOnSignal {
 		go s.waitForShutdown()
 	}
 
@@ -113,7 +113,7 @@ func (s *Server) Boot() error {
 // provided). Once Stop has been called, the server cannot be reused - future calls
 // to Run will return an error.
 //
-// If autoShutdown was set when calling Run, Stop will automatically be called by
+// If stopOnSignal was set when calling Run, Stop will automatically be called by
 // the server on receiving a TERM or INT signal from the OS. Otherwise, you must
 // call Stop when you want to shut down the Job Runner.
 func (s *Server) Stop() error {

--- a/job-runner/server/server.go
+++ b/job-runner/server/server.go
@@ -1,14 +1,17 @@
 // Copyright 2017-2018, Square, Inc.
 
-// Package server bootstraps the Job Runner.
+// Package server bootstraps and runs the Job Runner.
 package server
 
 import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
+	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/orcaman/concurrent-map"
 
 	"github.com/square/spincycle/config"
@@ -21,30 +24,80 @@ import (
 )
 
 type Server struct {
-	appCtx       app.Context
-	api          *api.API
+	appCtx        app.Context
+	api           *api.API
+	traverserRepo cmap.ConcurrentMap
+
 	shutdownChan chan struct{}
+	apiStopped   chan struct{}
+	stopMux      sync.Mutex
+	stopped      bool
 }
 
 func NewServer(appCtx app.Context) *Server {
 	return &Server{
 		appCtx:       appCtx,
+		stopMux:      sync.Mutex{},
+		apiStopped:   make(chan struct{}),
 		shutdownChan: make(chan struct{}),
 	}
 }
 
-// Run runs the Job Runner API in the foreground. It returns when the API stops.
-func (s *Server) Run() error {
-	if err := s.Boot(); err != nil {
-		return err
+// Run runs the Job Runner API in the foreground. It returns when the API stops
+// running (either from an error, or after a call to Stop). If a custom RunAPI
+// hook has been provided, it will be called to run the API instead of the default
+// api.Run.
+//
+// If autoShutdown = true, the server will listen for TERM and INT signals from the
+// OS and call Stop to shut itself down when those signals are received. Else, the \
+// caller must call Stop to shut down the server.
+func (s *Server) Run(autoShutdown bool) error {
+	if s.api == nil {
+		panic("Server.Run called before Server.Boot")
 	}
-	go s.waitForShutdown()
-	return s.api.Run() // returns after API is shut down
+	if s.stopped {
+		return fmt.Errorf("server stopped")
+	}
+
+	// If autoShutdown = true, watch for TERM + INT signals from the OS and shut
+	// down the Job Runner when we receive them.
+	if autoShutdown {
+		go s.waitForShutdown()
+	}
+
+	// Run the API - this will block until the API is stopped (or encounters
+	// some fatal error). If the RunAPI hook has been provided, call that instead
+	// of the default api.Run.
+	var err error
+	if s.appCtx.Hooks.RunAPI != nil {
+		err = s.appCtx.Hooks.RunAPI()
+	} else {
+		err = s.api.Run()
+	}
+
+	// If the server was stopped (as opposed to some error within the API), wait
+	// to make sure it's done shutting down the API before returning.
+	if s.stopped {
+		<-s.apiStopped
+	}
+
+	if err != nil {
+		return fmt.Errorf("error from API: %s", err)
+	}
+	return nil
 }
 
+// Boot sets up the server. It must be called before calling Run.
 func (s *Server) Boot() error {
+	// Only run Boot once.
 	if s.api != nil {
 		return nil
+	}
+
+	// Either both or neither RunAPI and StopAPI hooks must be provided - can't
+	// have just one.
+	if (s.appCtx.Hooks.RunAPI == nil) != (s.appCtx.Hooks.StopAPI == nil) {
+		return fmt.Errorf("Only one of RunAPI and StopAPI hooks provided - either both or neither must be provided.")
 	}
 	if err := s.loadConfig(); err != nil {
 		return err
@@ -55,6 +108,60 @@ func (s *Server) Boot() error {
 	return nil
 }
 
+// Stop stops the server. It signals running traversers to shut down and then
+// stops the API (using either the default api.Stop or the StopAPI hook if
+// provided). Once Stop has been called, the server cannot be reused - future calls
+// to Run will return an error.
+//
+// If autoShutdown was set when calling Run, Stop will automatically be called by
+// the server on receiving a TERM or INT signal from the OS. Otherwise, you must
+// call Stop when you want to shut down the Job Runner.
+func (s *Server) Stop() error {
+	// Only stop once. We lock the whole Stop call, so that, if Stop is called
+	// multiple times in quick succession, no calls will return before the server
+	// has actually been shut down.
+	s.stopMux.Lock()
+	defer s.stopMux.Unlock()
+	if s.stopped {
+		return nil
+	}
+	s.stopped = true
+
+	log.Infof("Stopping Job Runner server")
+
+	// Running traversers watch shutdownChan - closing this tells them to shut down.
+	// The API will also begin refusing to start running new job chains.
+	close(s.shutdownChan)
+
+	// Wait for all traversers to shut down. Timeout if they aren't done
+	// within 20 seconds, and continue to shutting down the API.
+	timeout := time.After(20 * time.Second)
+WAIT_FOR_TRAVERSERS:
+	for !s.traverserRepo.IsEmpty() {
+		select {
+		case <-time.After(10 * time.Millisecond):
+			// Check again if traversers are all done.
+		case <-timeout:
+			break WAIT_FOR_TRAVERSERS
+		}
+	}
+
+	// Stop the API, using the StopAPI hook if provided and api.Stop otherwise.
+	var err error
+	if s.appCtx.Hooks.StopAPI != nil {
+		err = s.appCtx.Hooks.StopAPI()
+	} else {
+		err = s.api.Stop()
+	}
+	close(s.apiStopped) // indicate to Run that the API is done shutting down
+
+	if err != nil {
+		return fmt.Errorf("error stopping API: %s", err)
+	}
+	return nil
+}
+
+// API returns the Job Runner API created in Boot.
 func (s *Server) API() *api.API {
 	return s.api
 }
@@ -68,8 +175,10 @@ func (s *Server) waitForShutdown() {
 
 	<-sigChan
 
-	// API + traversers watch shutdownChan
-	close(s.shutdownChan)
+	err := s.Stop()
+	if err != nil {
+		log.Errorf("error shutting down server: %s", err)
+	}
 }
 
 func (s *Server) loadConfig() error {
@@ -112,8 +221,15 @@ func (s *Server) makeAPI() error {
 	stat := status.NewManager(chainRepo)
 	rf := runner.NewFactory(jobs.Factory, rmc)
 	trFactory := chain.NewTraverserFactory(chainRepo, rf, rmc, s.shutdownChan)
-	trRepo := cmap.New()
+	s.traverserRepo = cmap.New()
 
-	s.api = api.NewAPI(s.appCtx, trFactory, trRepo, stat, s.shutdownChan)
+	apiCfg := api.Config{
+		AppCtx:           s.appCtx,
+		TraverserFactory: trFactory,
+		TraverserRepo:    s.traverserRepo,
+		StatusManager:    stat,
+		ShutdownChan:     s.shutdownChan,
+	}
+	s.api = api.NewAPI(apiCfg)
 	return nil
 }

--- a/request-manager/app/app.go
+++ b/request-manager/app/app.go
@@ -29,7 +29,7 @@ import (
 
 // Context represents the config, core service singletons, and 3rd-party extensions.
 // There is one immutable context shared by many packages, created in Server.Boot,
-// called appCtx.
+// called api.appCtx.
 type Context struct {
 	// User-provided config from config file
 	Config config.RequestManager
@@ -78,6 +78,17 @@ type Hooks struct {
 	// and overrides the username. The request fails and returns HTTP 500 if it
 	// returns an error.
 	SetUsername func(*http.Request) (string, error)
+
+	// RunAPI runs the Request Manager API. It should block until the API is
+	// stopped via a call to StopAPI. If this hook is provided, it is called
+	// instead of api.Run(). If you provide this hook, you need to provide StopAPI
+	// as well.
+	RunAPI func() error
+
+	// StopAPI stops running the Request Manager API - it's called after RunAPI
+	// when the Request Manager is shutting down, and it should cause RunAPI to
+	// return. If you provide this hook, you need to provide RunAPI as well.
+	StopAPI func() error
 }
 
 // Plugins allow users to provide custom components. All plugins are optional;

--- a/request-manager/bin/main.go
+++ b/request-manager/bin/main.go
@@ -14,6 +14,6 @@ func main() {
 	if err := s.Boot(); err != nil {
 		log.Fatalf("Error starting Request Manager: %s", err)
 	}
-	err := s.Run()
+	err := s.Run(true)
 	log.Fatalf("Request Manager stopped: %s", err)
 }

--- a/request-manager/request/resumer_test.go
+++ b/request-manager/request/resumer_test.go
@@ -426,15 +426,16 @@ func TestCleanup(t *testing.T) {
 	defer teardownResumer(t, dbName)
 
 	cfg := request.ResumerConfig{
-		RequestManager: rm,
-		DBConnector:    dbc,
-		JRClient:       &mock.JRClient{},
-		RMHost:         "hostname",
-		ShutdownChan:   shutdownChan,
+		RequestManager:       rm,
+		DBConnector:          dbc,
+		JRClient:             &mock.JRClient{},
+		RMHost:               "hostname",
+		ShutdownChan:         shutdownChan,
+		SuspendedJobChainTTL: time.Hour,
 	}
 	r := request.NewResumer(cfg)
 
-	r.Cleanup(time.Hour)
+	r.Cleanup()
 
 	// Expectation for each SJC:
 	//  suspended___________: nothing
@@ -507,7 +508,7 @@ func TestCleanup(t *testing.T) {
 		t.Errorf("request %s state = %s, expected %s", req.Id, proto.StateName[req.State], "FAIL")
 	}
 
-	r.Cleanup(time.Hour)
+	r.Cleanup()
 
 	// Expectation for each SJC:
 	//  suspended___________: nothing

--- a/request-manager/server/server.go
+++ b/request-manager/server/server.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/square/spincycle/request-manager/api"
 	"github.com/square/spincycle/request-manager/app"
@@ -19,71 +22,144 @@ import (
 	"github.com/square/spincycle/request-manager/status"
 )
 
+var (
+	// How often the request resumer is run.
+	ResumerCadence = 10 * time.Second
+
+	// How long Suspended Job Chains have to be resumed before they're deleted.
+	SJCTTL = 1 * time.Hour
+)
+
 type Server struct {
-	appCtx  app.Context
-	api     *api.API
-	sigChan chan os.Signal
+	appCtx app.Context
+	api    *api.API
+
+	shutdownChan   chan struct{}
+	resumerStopped chan struct{}
+	apiStopped     chan struct{}
+	stopped        bool
+	stopMux        sync.Mutex
 }
 
 func NewServer(appCtx app.Context) *Server {
 	return &Server{
-		appCtx: appCtx,
+		appCtx:         appCtx,
+		resumerStopped: make(chan struct{}),
+		apiStopped:     make(chan struct{}),
+		shutdownChan:   make(chan struct{}),
+		stopMux:        sync.Mutex{},
 	}
 }
 
-// Run runs the Request Manager API in the foreground. It returns when the API stops.
-func (s *Server) Run() error {
+// Run runs the Request Manager API and Request Resumer. It returns when the API
+// stops running (either from an error, or after a call to Stop). If a custom RunAPI
+// hook has been provided, it will be called to run the API instead of the default
+// api.Run.
+//
+// If autoShutdown = true, the server will listen for TERM and INT signals from the
+// OS and call Stop to shut itself down when those signals are received. Else, the
+// caller must call Stop to shut down the server.
+func (s *Server) Run(autoShutdown bool) error {
 	if s.api == nil {
 		panic("Server.Run called before Server.Boot")
 	}
+	if s.stopped {
+		return fmt.Errorf("server stopped")
+	}
 
-	// Run the request resumer.
-	resumerDone := make(chan struct{})
+	// Run the request resumer in a goroutine, so we can block on running the api.
 	go func() {
-		defer close(resumerDone)
+		defer close(s.resumerStopped) // indicate the resumer is done running
 
-		// Every 10 seconds until shutdown, resume all SJCs and clean up any
-		// SJCs in a bad state.
-		ticker := time.NewTicker(10 * time.Second)
+		// Every 10 seconds until the server is stopped, resume all Suspended Job
+		// Chains and clean up any that are in a bad state.
+		ticker := time.NewTicker(ResumerCadence)
 	RESUMER:
 		for {
 			select {
-			case <-s.appCtx.ShutdownChan:
+			case <-s.shutdownChan:
 				break RESUMER
 			case <-ticker.C:
 				s.appCtx.RR.ResumeAll()
-				s.appCtx.RR.Cleanup(1 * time.Hour)
+				s.appCtx.RR.Cleanup()
 			}
 		}
 		ticker.Stop()
 	}()
 
-	go s.waitForShutdown()
-
-	// Run the RM API.
-	err := s.api.Run()
-
-	// If api returned because the RM is shutting down, wait for the resumer to
-	// stop running as well.
-	select {
-	case <-s.appCtx.ShutdownChan:
-		<-resumerDone
-	default:
+	// If autoShutdown = true, watch for TERM + INT signals from the OS and shut
+	// down the Request Manager when we receive them.
+	if autoShutdown {
+		go s.waitForShutdown()
 	}
 
-	return err
+	// Run the API - this will block until the API is stopped (or encounters
+	// some fatal error). If the RunAPI hook has been provided, call that instead
+	// of the default api.Run.
+	var err error
+	if s.appCtx.Hooks.RunAPI != nil {
+		err = s.appCtx.Hooks.RunAPI()
+	} else {
+		err = s.api.Run()
+	}
+
+	// If the server was stopped (as opposed to some error within the API), wait
+	// to make sure it's done shutting down the API and resumer before returning.
+	if s.stopped {
+		<-s.apiStopped
+		<-s.resumerStopped
+	}
+
+	if err != nil {
+		return fmt.Errorf("error from API: %s", err)
+	}
+	return nil
 }
 
-// Catch TERM and INT signals to gracefully shut down the Request Manager
-func (s *Server) waitForShutdown() {
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+// Stop stops the running Request Resumer and API. It signals the resumer to shut
+// down and then stops the API (using either the default api.Stop or the StopAPI
+// hook if provided). Once Stop has been called, the server cannot be reused -
+// future calls to Run will return an error.
+//
+// If autoShutdown was set when calling Run, Stop will automatically be called by
+// the server on receiving a TERM or INT signal from the OS. Otherwise, you must
+// call Stop when you want to shut down the Request Manager.
+func (s *Server) Stop() error {
+	// Only stop once. We lock the whole Stop call, so that, if Stop is called
+	// multiple times in quick succession, no calls will return before the server
+	// has actually been shut down.
+	s.stopMux.Lock()
+	defer s.stopMux.Unlock()
+	if s.stopped {
+		return nil
+	}
+	s.stopped = true
 
-	<-sigChan
+	log.Infof("Stopping Request Manager server")
 
-	close(s.appCtx.ShutdownChan)
+	// Stops the request resumer loop. The API will also begin refusing to start
+	// running new requests.
+	close(s.shutdownChan)
+
+	// Stop the API, using the StopAPI hook if provided and api.Stop otherwise.
+	var err error
+	if s.appCtx.Hooks.StopAPI != nil {
+		err = s.appCtx.Hooks.StopAPI()
+	} else {
+		err = s.api.Stop()
+	}
+	close(s.apiStopped) // indicate to Run that the API is done shutting down
+
+	// Wait to return until the resumer has been stopped.
+	<-s.resumerStopped
+
+	if err != nil {
+		return fmt.Errorf("error stopping API: %s", err)
+	}
+	return nil
 }
 
+// Boot sets up the server. It must be called before calling Run.
 func (s *Server) Boot() error {
 	// Load config file
 	cfg, err := s.appCtx.Hooks.LoadConfig(s.appCtx)
@@ -118,7 +194,7 @@ func (s *Server) Boot() error {
 	}
 
 	// Request Manager: core logic and coordination
-	s.appCtx.RM = request.NewManager(grf, dbc, jrc, s.appCtx.ShutdownChan)
+	s.appCtx.RM = request.NewManager(grf, dbc, jrc, s.shutdownChan)
 
 	// Request Resumer: suspend + resume requests
 	hostname, err := os.Hostname()
@@ -126,11 +202,12 @@ func (s *Server) Boot() error {
 		return fmt.Errorf("error getting hostname: %s", err)
 	}
 	resumerConfig := request.ResumerConfig{
-		RequestManager: s.appCtx.RM,
-		DBConnector:    dbc,
-		JRClient:       jrc,
-		RMHost:         hostname,
-		ShutdownChan:   s.appCtx.ShutdownChan,
+		RequestManager:       s.appCtx.RM,
+		DBConnector:          dbc,
+		JRClient:             jrc,
+		RMHost:               hostname,
+		ShutdownChan:         s.shutdownChan,
+		SuspendedJobChainTTL: SJCTTL,
 	}
 	s.appCtx.RR = request.NewResumer(resumerConfig)
 
@@ -141,7 +218,7 @@ func (s *Server) Boot() error {
 	s.appCtx.JLS = joblog.NewStore(dbc)
 
 	// Auth Manager: request authorization (pre- (built-in) and post- using plugin)
-	s.appCtx.Auth = auth.NewManager(s.appCtx.Plugins.Auth, MapACL(specs), cfg.Auth.AdminRoles, cfg.Auth.Strict)
+	s.appCtx.Auth = auth.NewManager(s.appCtx.Plugins.Auth, mapACL(specs), cfg.Auth.AdminRoles, cfg.Auth.Strict)
 
 	// API: endpoints and controllers, also handles auth via auth plugin
 	s.api = api.NewAPI(s.appCtx)
@@ -149,12 +226,28 @@ func (s *Server) Boot() error {
 	return nil
 }
 
+// API returns the Request Manager API created in Boot.
 func (s *Server) API() *api.API {
 	return s.api
 }
 
+// --------------------------------------------------------------------------
+
+// Catch TERM and INT signals to gracefully shut down the Request Manager
+func (s *Server) waitForShutdown() {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	<-sigChan
+
+	err := s.Stop()
+	if err != nil {
+		log.Errorf("error shutting down server: %s", err)
+	}
+}
+
 // MapACL maps spec file ACL to auth.ACL structure.
-func MapACL(specs grapher.Config) map[string][]auth.ACL {
+func mapACL(specs grapher.Config) map[string][]auth.ACL {
 	acl := map[string][]auth.ACL{}
 	for name, spec := range specs.Sequences {
 		if len(spec.ACL) == 0 {

--- a/test/mock/request.go
+++ b/test/mock/request.go
@@ -5,7 +5,6 @@ package mock
 import (
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/square/spincycle/proto"
 	"github.com/square/spincycle/request-manager/auth"
@@ -95,7 +94,7 @@ func (r *RequestManager) JobChain(reqId string) (proto.JobChain, error) {
 
 type RequestResumer struct {
 	ResumeAllFunc func()
-	CleanupFunc   func(time.Duration)
+	CleanupFunc   func()
 	ResumeFunc    func(string) error
 	SuspendFunc   func(proto.SuspendedJobChain) error
 }
@@ -107,9 +106,9 @@ func (r *RequestResumer) ResumeAll() {
 	return
 }
 
-func (r *RequestResumer) Cleanup(ttl time.Duration) {
+func (r *RequestResumer) Cleanup() {
 	if r.CleanupFunc != nil {
-		r.CleanupFunc(ttl)
+		r.CleanupFunc()
 	}
 	return
 }


### PR DESCRIPTION
Need this so we can run the API by calling server.Run(), instead of getting the api with server.API() and running it ourselves, since server.Run() handles shutdown and (in the RM) runs the Resumer.