### PR TITLE
Add specs when running spincycle locally in /dev

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -8,7 +8,7 @@ Presuming,
 1. The `jobs` symlink points to the jobs repo you want (default: `dev/jobs`)
 1. MySQL is running on localhost:3306 with root user having no password
 1. Have not run the script before
-1. The specs symlink points to the specs you want (default: dev/specs)
+1. The `dev/specs` directory contains the request specs you want.
 
 then running `run-spincycle` should "Just Work" and "Do the Right Thing", like:
 

--- a/dev/run-spincycle
+++ b/dev/run-spincycle
@@ -206,6 +206,13 @@ build() {
     echo "Using development sandbox jobs"
   fi
 
+  if [[ ! -d "$SANDBOX_DIR/specs" ]]; then
+    echo "Installing development sandbox specs..."
+    cp -r $DEV_DIR/specs $SANDBOX_DIR
+  else
+    echo "Using development sandbox specs"
+  fi
+
   if [[ ! -x "$RM_BIN" ]] || [[ "$BUILD" ]]; then
     echo "Building request manager..."
     cd "$REPO_ROOT_DIR/request-manager/bin"

--- a/dev/specs/test.yaml
+++ b/dev/specs/test.yaml
@@ -1,0 +1,48 @@
+---
+sequences:
+  test:
+    request: true
+    args:
+      required:
+      optional:
+        - name: sleepTime
+          desc: "How long to sleep (milliseconds) during the request. Useful to verify how RM and JR respond before request has finished."
+          default: "1000"
+    nodes:
+      noop:
+        category: job
+        type: noop
+        args:
+        sets: []
+        deps: []
+
+      # Both wait sequences happen simultaneously
+      wait-1:
+        category: sequence
+        type: wait
+        args:
+          - expected: sleepTime
+            given: sleepTime
+        sets: []
+        deps: [noop]
+      wait-2:
+        category: sequence
+        type: wait
+        args:
+          - expected: sleepTime
+            given: sleepTime
+        sets: []
+        deps: [noop]
+  wait:
+    args:
+      required:
+        - name: sleepTime
+    nodes:
+      wait:
+        category: job
+        type: sleep
+        args:
+          - expected: duration
+            given: sleepTime
+        sets: []
+        deps: []


### PR DESCRIPTION
- Add a stoppable sleep job to the dev job factory
- Add a test request spec (with that sleep job) in /dev/specs
- Update run-spincycle to run spincycle with the specs in /dev/specs

Overall, this is just to make testing easier - now you can actually test running a request using `spinc --env dev` commands.