### PR TITLE
1.0-rc2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ Spin Cycle can do anything you can program. The database team at [Square](https:
 * [Auth](v1.0/operate/auth)
 
 ## Develop
+* [Dev Env](v1.0/develop/dev-env)
 * [Jobs](v1.0/develop/jobs)
 * [Requests](v1.0/develop/requests)
 * [Extensions](v1.0/develop/extensions)

--- a/docs/v1.0/operate/configure.md
+++ b/docs/v1.0/operate/configure.md
@@ -56,15 +56,15 @@ The config file is YAML with multiple sections: `server`, `mysql`, `specs`, etc.
 server:
   addr: 10.0.0.50:32308
   tls:
-    cert_file: myorg.crt
-    key_file: myorg.key
-    ca_file: myorg.ca
+    cert_file: /secret/mycorp.crt
+    key_file:  /secret/mycorp.key
+    ca_file:   /secret/mycorp.ca
 mysql:
   dsn: "spincycle@tcp(spin-mysql.local:3306)/spincycle_production"
 specs:
   dir: /data/app/spin-rm/specs/
 jr_client:
-  url: https://spincycle-jr.myorg.local:32307
+  url: https://spincycle-jr.mycorp.local:32307
 ```
 
 ## Environment Variables
@@ -81,13 +81,15 @@ Take a config option, change `.` to `_`, upper-case everything, and add `SPINCYC
 
 <a id="rm.jr_client.url">jr_client.url</a>: URL that Request Manager uses to connect to any Job Runner. If TLS enabled on JR, use "https" and configure TLS. In production, this is usually a load balancer address in front of N-many JR instances.
 
-<a id="rm.jr_client.tls">jr_client.tls</a>: Enable TLS when RM connects to any JR at [jr_client.url](#rm.jr_client.url).
+<a id="rm.jr_client.tls">jr_client.tls</a>: Enable TLS when RM connects to any JR at [jr_client.url](#rm.jr_client.url). See common [TLS](#tls) section below.
 
 <a id="rm.mysql.dsn">mysql.dsn</a>: [DSN](https://github.com/go-sql-driver/mysql#dsn-data-source-name) specifying connection to MySQL. The DSN must specify the database, for example: `/spincycle_production`. Do use `tls` DSN parameter, specify the TLS config and Spin Cycle will add the `tls` DSN parameter automatically.
 
+<a id="rm.mysql.tls">mysql.tls</a>: Enable TLS connection to MySQL. See common [TLS](#tls) section below.
+
 <a id="rm.server.addr">server.addr</a>: Network address:port to listen on. To listen on all interfaces on the default port, specify ":32308".
 
-<a id="rm.server.tls">server.tls</a>: Enable TLS for clients (users) and when JR connects to RM.
+<a id="rm.server.tls">server.tls</a>: Enable TLS for clients (users) and when JR connects to RM. See common [TLS](#tls) section below.
 
 <a id="rm.specs.dir">specs.dir</a>: Directory containing all request spec files. Subdirectories are ignored. The default is "specs/", relative to current working dir.
 
@@ -95,11 +97,11 @@ Take a config option, change `.` to `_`, upper-case everything, and add `SPINCYC
 
 <a id="jr.rm_client.url">rm_client.url</a>: URL that Job Runner uses to connect to any Request Manager. If TLS enabled on RM, use "https" and configure TLS. In production, this is usually a load balancer address in front of N-many RM instances.
 
-<a id="jr.rm_client.tls">rm_client.tls</a>: Enable TLS when JR connects to any RM at [rm_client.url](#jr.rm_client.url).
+<a id="jr.rm_client.tls">rm_client.tls</a>: Enable TLS when JR connects to any RM at [rm_client.url](#jr.rm_client.url). See common [TLS](#tls) section below.
 
 <a id="jr.server.addr">server.addr</a>: Network address:port to listen on and to report to RM. _This must be the address of the specific JR instance that RM can connect to._ Do not use a load balancer address.
 
-<a id="jr.server.tls">server.tls</a>: Enable TLS for incoming connections from RM.
+<a id="jr.server.tls">server.tls</a>: Enable TLS for incoming connections from RM. See common [TLS](#tls) section below.
 
 ## TLS
 

--- a/docs/v1.0/operate/spinc.md
+++ b/docs/v1.0/operate/spinc.md
@@ -11,7 +11,7 @@ spinc is the command line interface (CLI) for humans to operate Spin Cycle. spin
 
 ## addr
 
-spinc needs the Request Manager address specified by `--addr`, or `ADDR` environment variable, or `addr: <URL>` in `/etc/spinc/spinc.yaml` or `~/.spinc.yaml`. Setting `addr` in one of the config YAML files is probably easiest. If many RM are deployed, this should be the URL of the load balancer.
+spinc needs the Request Manager address specified by `--addr`, or `SPINC_ADDR` environment variable, or `addr: <URL>` in `/etc/spinc/spinc.yaml` or `~/.spinc.yaml`. Setting `addr` in one of the config YAML files is probably easiest. If many RM are deployed, this should be the URL of the load balancer.
 
 Once `addr` is set, run `spinc` (no arguments) to list available requests:
 
@@ -53,4 +53,16 @@ Run `spinc start <request>` to start a request by name. It will prompt you for r
 
 Use `spinc status <request ID>` and `spinc log <request ID>` to check the status and results of a request.
 
-`spinc ps` shows all running requests/jobs, analogous to Unix ps.
+`spinc ps` shows all running requests/jobs, analogous to Unix ps. You can specify an optional request ID to show only its running jobs.
+
+## Environment Variables
+
+| Option | Environment Variable |
+| ------ | -------------------- |
+| --addr | SPINC_ADDR |
+| --config | SPINC_CONFIG |
+| --debug | SPINC_DEBUG |
+| --env | SPINC_ENV |
+| --timeout | SPINC_TIMEOUT |
+
+Options not listed do not have an environment variable.

--- a/request-manager/status/manager.go
+++ b/request-manager/status/manager.go
@@ -181,18 +181,16 @@ func (m *manager) UpdateProgress(prg proto.RequestProgress) error {
 	if err != nil {
 		return err
 	}
-
-	switch cnt {
-	case 0:
-		// @todo: check if it didn't match because state != RUNNING
-		return serr.RequestNotFound{prg.RequestId}
-	case 1:
-		return nil
-	default:
+	if cnt > 1 {
 		// This should be impossible since we specify the primary key
 		// in the WHERE clause of the update.
 		return fmt.Errorf("UpdateProgress: request_id = %s matched %d rows, expected 1", prg.RequestId, cnt)
 	}
+
+	// Presuming the request ID is correct and request is running, cnt = 0 happens
+	// when finished_jobs = prg.FinishedJobs, i.e. no more finished jobs since last
+	// update. cnt = 1 happens when we increment finished jobs.
+	return nil
 }
 
 func (m *manager) jrURLS() ([]string, error) {

--- a/spinc/cmd/cmd.go
+++ b/spinc/cmd/cmd.go
@@ -73,3 +73,12 @@ func SqueezeString(s string, n int, x string) string {
 	left := r - right
 	return s[0:left] + x + s[ls-right:ls]
 }
+
+func QuoteArgValue(val string) string {
+	// If no whitespace or quotes, no change
+	if !strings.ContainsAny(val, " \t") && !strings.ContainsAny(val, `"`) {
+		return val
+	}
+	// Return in "" and escape inner ", if any
+	return `"` + strings.Replace(val, `"`, `\"`, -1) + `"`
+}

--- a/spinc/cmd/cmd_test.go
+++ b/spinc/cmd/cmd_test.go
@@ -62,3 +62,18 @@ func TestSqueezeString(t *testing.T) {
 		t.Errorf("got '%s', expected '%s'", got, expect)
 	}
 }
+
+func TestQuoteArgValue(t *testing.T) {
+	inputs := [][]string{
+		{"foo", "foo"},           // no spaces or quotes = no change
+		{"foo bar", `"foo bar"`}, // space
+		{"foo	bar", `"foo	bar"`}, // tab
+		{`the "inner" quote`, `"the \"inner\" quote"`}, // escape inner quotes
+	}
+	for _, v := range inputs {
+		got := cmd.QuoteArgValue(v[0])
+		if got != v[1] {
+			t.Errorf("got '%s', expected '%s'", got, v[1])
+		}
+	}
+}

--- a/spinc/cmd/help.go
+++ b/spinc/cmd/help.go
@@ -83,7 +83,7 @@ func (c *Help) Usage() {
 		"  --debug    Print debug to stderr\n"+
 		"  --env      Environment (dev, staging, production)\n"+
 		"  --help     Print help\n"+
-		"  --timeout  API timeout, milliseconds (default: %d)\n"+
+		"  --timeout  API timeout, milliseconds (default: %d ms)\n"+
 		"  --version  Print version\n"+
 		"Commands:\n"+
 		"  help    <cmd|req>  Print command or request help\n"+
@@ -101,7 +101,7 @@ func (c *Help) Usage() {
 
 func (c *Help) QuickHelp() {
 	if c.ctx.RMClient == nil {
-		fmt.Fprintf(c.ctx.Out, "Specify --addr or ADDR environment variable to list all requests\n")
+		fmt.Fprintf(c.ctx.Out, "Specify --addr or SPINC_ADDR environment variable to list all requests\n")
 		fmt.Fprintf(c.ctx.Out, "Run 'spinc help' for usage\n")
 	} else {
 		fmt.Fprintf(c.ctx.Out, "Request Manager address: %s\n\n", c.ctx.Options.Addr)

--- a/spinc/cmd/info.go
+++ b/spinc/cmd/info.go
@@ -64,7 +64,8 @@ func (c *Info) Run() error {
 		if arg.Type == "static" {
 			continue
 		}
-		args = append(args, fmt.Sprintf("%s=%s", arg.Name, arg.Value))
+		val := fmt.Sprintf("%s", arg.Value)
+		args = append(args, fmt.Sprintf("%s=%s", arg.Name, QuoteArgValue(val)))
 	}
 
 	fmt.Fprintf(c.ctx.Out, "      id: %s\n", r.Id)

--- a/spinc/cmd/start.go
+++ b/spinc/cmd/start.go
@@ -200,14 +200,14 @@ func (c *Start) Cmd() string {
 	fullCmd := "start " + c.reqName
 	args := map[string]interface{}{}
 	for _, i := range c.requiredArgs {
-		fullCmd += " " + i.Name + "=" + i.Value
+		fullCmd += " " + i.Name + "=" + QuoteArgValue(i.Value)
 		if i.Value != "" {
 			args[i.Name] = i.Value
 		}
 	}
 	for _, i := range c.optionalArgs {
 		if !i.IsDefault {
-			fullCmd += " " + i.Name + "=" + i.Value
+			fullCmd += " " + i.Name + "=" + QuoteArgValue(i.Value)
 			args[i.Name] = i.Value
 		}
 	}

--- a/spinc/cmd/status_test.go
+++ b/spinc/cmd/status_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/square/spincycle/test/mock"
 )
 
-func TestStatus(t *testing.T) {
+func TestStatusRunning(t *testing.T) {
 	output := &bytes.Buffer{}
 	createdAt := time.Now().Add(-5 * time.Second)
 	startedAt := time.Now().Add(-5 * time.Second)
@@ -65,6 +65,134 @@ progress: 11%
  request: requestname
   caller: owner
     args: key=value key2=val2
+`
+	if output.String() != expectOutput {
+		fmt.Printf("got output:\n%s\nexpected:\n%s\n", output, expectOutput)
+		t.Error("wrong output, see above")
+	}
+}
+
+func TestStatusFinished(t *testing.T) {
+	output := &bytes.Buffer{}
+	createdAt := time.Now().Add(-120 * time.Minute)
+	startedAt := time.Now().Add(-120 * time.Minute)
+	finishedAt := time.Now().Add(-1 * time.Second)
+	request := proto.Request{
+		Id:           "b9uvdi8tk9kahl8ppvbg",
+		Type:         "requestname",
+		State:        proto.STATE_COMPLETE,
+		User:         "owner",
+		Args:         args,
+		TotalJobs:    9,
+		FinishedJobs: 9,
+		CreatedAt:    createdAt,
+		StartedAt:    &startedAt,
+		FinishedAt:   &finishedAt,
+	}
+	rmc := &mock.RMClient{
+		GetRequestFunc: func(id string) (proto.Request, error) {
+			if id == request.Id {
+				return request, nil
+			}
+			return proto.Request{}, nil
+		},
+	}
+	ctx := app.Context{
+		Out:      output,
+		RMClient: rmc,
+		Options:  config.Options{},
+		Command: config.Command{
+			Cmd:  "status",
+			Args: []string{request.Id},
+		},
+	}
+	status := cmd.NewStatus(ctx)
+
+	err := status.Prepare()
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = status.Run()
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectOutput := `   state: COMPLETE
+progress: 100%
+ runtime: 1h59m59s
+ request: requestname
+  caller: owner
+    args: key=value key2=val2
+`
+	if output.String() != expectOutput {
+		fmt.Printf("got output:\n%s\nexpected:\n%s\n", output, expectOutput)
+		t.Error("wrong output, see above")
+	}
+}
+
+func TestStatusArgValueQuoting(t *testing.T) {
+	var args []proto.RequestArg = []proto.RequestArg{
+		{
+			Name:  "a",
+			Type:  proto.ARG_TYPE_REQUIRED,
+			Value: "foo bar",
+		},
+		{
+			Name:  "b",
+			Type:  proto.ARG_TYPE_REQUIRED,
+			Value: `has "inner" quote`,
+		},
+	}
+	output := &bytes.Buffer{}
+	createdAt := time.Now().Add(-5 * time.Second)
+	startedAt := time.Now().Add(-5 * time.Second)
+	request := proto.Request{
+		Id:           "b9uvdi8tk9kahl8ppvbg",
+		Type:         "requestname",
+		State:        proto.STATE_RUNNING,
+		User:         "owner",
+		Args:         args,
+		TotalJobs:    9,
+		FinishedJobs: 1,
+		CreatedAt:    createdAt,
+		StartedAt:    &startedAt,
+	}
+	rmc := &mock.RMClient{
+		GetRequestFunc: func(id string) (proto.Request, error) {
+			if id == request.Id {
+				return request, nil
+			}
+			return proto.Request{}, nil
+		},
+	}
+	ctx := app.Context{
+		Out:      output,
+		RMClient: rmc,
+		Options:  config.Options{},
+		Command: config.Command{
+			Cmd:  "status",
+			Args: []string{request.Id},
+		},
+	}
+	status := cmd.NewStatus(ctx)
+
+	err := status.Prepare()
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = status.Run()
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectOutput := `   state: RUNNING
+progress: 11%
+ runtime: 5s
+ request: requestname
+  caller: owner
+    args: a="foo bar" b="has \"inner\" quote"
 `
 	if output.String() != expectOutput {
 		fmt.Printf("got output:\n%s\nexpected:\n%s\n", output, expectOutput)

--- a/spinc/config/config.go
+++ b/spinc/config/config.go
@@ -24,13 +24,12 @@ const (
 
 // Options represents typical command line options: --addr, --config, etc.
 type Options struct {
-	Addr    string `arg:"env" yaml:"addr"`
-	Config  string `arg:"env"`
-	Debug   bool
-	Env     string
+	Addr    string `arg:"env:SPINC_ADDR" yaml:"addr"`
+	Config  string `arg:"env:SPINC_CONFIG"`
+	Debug   bool   `arg:"env:SPINC_DEBUG" yaml:"debug"`
+	Env     string `arg:"env:SPINC_ENV" yaml:"env"`
 	Help    bool
-	Ping    bool
-	Timeout uint `arg:"env" yaml:"timeout"`
+	Timeout uint `arg:"env:SPINC_TIMEOUT" yaml:"timeout"`
 	Version bool
 }
 


### PR DESCRIPTION
* Fix spinc status runtime.
* Prefix spinc env vars with SPINC_ and document.
* Add mysql.tls config section to docs.
* Don't log "request not found" when JR updates finished jobs (see code comment).
* Make spinc quote arg values when needed.