### PR TITLE
make job exit codes unsigned integers

### DIFF
--- a/dev/jobs/factory.go
+++ b/dev/jobs/factory.go
@@ -108,7 +108,7 @@ func (j *ShellCommand) Run(jobData map[string]interface{}) (job.Return, error) {
 	cmd.Stderr = &stderr
 
 	// Run the cmd and wait for it to return
-	exit := int64(0)
+	exit := uint64(0)
 	err := cmd.Run()
 	ret := job.Return{
 		Exit:   exit,

--- a/job/job.go
+++ b/job/job.go
@@ -154,7 +154,7 @@ type Factory interface {
 // is successful but reports Error = ErrRecordNotFound for logging.
 type Return struct {
 	State  byte   // proto/STATE_ const
-	Exit   int64  // Unix exit code
+	Exit   uint64 // Unix exit code
 	Error  error  // Go error
 	Stdout string // stdout output
 	Stderr string // stderr output

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -158,7 +158,7 @@ type JobLog struct {
 	FinishedAt int64  `json:"finishedAt"` // when job finished, regardless of state (UnixNano)
 
 	State  byte   `json:"state"`  // STATE_* const
-	Exit   int64  `json:"exit"`   // unix exit code
+	Exit   uint64 `json:"exit"`   // unix exit code
 	Error  string `json:"error"`  // error message
 	Stdout string `json:"stdout"` // stdout output
 	Stderr string `json:"stderr"` // stderr output

--- a/request-manager/joblog/store.go
+++ b/request-manager/joblog/store.go
@@ -101,7 +101,7 @@ func (s *store) Get(requestId, jobId string) (proto.JobLog, error) {
 		jl.Stderr = stderr.String
 	}
 	if exit.Valid {
-		jl.Exit = exit.Int64
+		jl.Exit = uint64(exit.Int64)
 	}
 
 	return jl, nil
@@ -154,7 +154,7 @@ func (s *store) GetFull(requestId string) ([]proto.JobLog, error) {
 			l.Stderr = stderr.String
 		}
 		if exit.Valid {
-			l.Exit = exit.Int64
+			l.Exit = uint64(exit.Int64)
 		}
 
 		jl = append(jl, l)


### PR DESCRIPTION
exit codes are stored in the job_logs table as TINYINT UNSIGNED, so they should be unsigned integers in job.Return.Exit and proto.JobLog.Exit.