### PR TITLE
Add required columns to request-manager test data

### DIFF
--- a/request-manager/test/data/jc-bad.sql
+++ b/request-manager/test/data/jc-bad.sql
@@ -3,4 +3,4 @@
 */
 
 -- an invalid job chain
-INSERT INTO request_archives (request_id, create_request, job_chain) VALUES ("cd724fd12092", '{"some":"param"}', '{"requestId":"8bff5def4f3fvh78skjy","jobs":{"this is not valid json"}},"adjacencyList":null,"state":4}');
+INSERT INTO request_archives (request_id, create_request, args, job_chain) VALUES ("cd724fd12092", '{"some":"param"}', '', '{"requestId":"8bff5def4f3fvh78skjy","jobs":{"this is not valid json"}},"adjacencyList":null,"state":4}');

--- a/request-manager/test/data/jc-default.sql
+++ b/request-manager/test/data/jc-default.sql
@@ -3,4 +3,4 @@
 */
 
 -- a failed job chain
-INSERT INTO request_archives (request_id, create_request, job_chain) VALUES ("8bff5def4f3fvh78skjy", '{"some":"param"}', '{"requestId":"8bff5def4f3fvh78skjy","jobs":{"vr34":{"id":"vr34","type":"noop","bytes":null,"state":4,"args":null,"data":null,"retry":0}},"adjacencyList":null,"state":4}');
+INSERT INTO request_archives (request_id, create_request, args, job_chain) VALUES ("8bff5def4f3fvh78skjy", '{"some":"param"}', '', '{"requestId":"8bff5def4f3fvh78skjy","jobs":{"vr34":{"id":"vr34","type":"noop","bytes":null,"state":4,"args":null,"data":null,"retry":0}},"adjacencyList":null,"state":4}');

--- a/request-manager/test/data/request-default.sql
+++ b/request-manager/test/data/request-default.sql
@@ -4,24 +4,24 @@
 
 -- a pending request + job chain
 INSERT INTO requests (request_id, type, user, created_at, state) VALUES ("0874a524aa1edn3ysp00", 'some-type', 'john', '2017-09-13 00:00:00', 1);
-INSERT INTO request_archives (request_id, create_request, job_chain) VALUES ("0874a524aa1edn3ysp00", '{"some":"param"}', '{"requestId":"0874a524aa1edn3ysp00","jobs":{"1q2w":{"id":"1q2w","type":"dummy","bytes":null,"state":1,"args":null,"data":null,"retry":0}},"adjacencyList":null,"state":1}');
+INSERT INTO request_archives (request_id, create_request, args, job_chain) VALUES ("0874a524aa1edn3ysp00", '{"some":"param"}', '', '{"requestId":"0874a524aa1edn3ysp00","jobs":{"1q2w":{"id":"1q2w","type":"dummy","bytes":null,"state":1,"args":null,"data":null,"retry":0}},"adjacencyList":null,"state":1}');
 
 -- a running request + job chain + job logs
 INSERT INTO requests (request_id, type, created_at, state, total_jobs, finished_jobs, jr_url) VALUES ("454ae2f98a05cv16sdwt", 'do-something', '2017-09-13 01:00:00', 2, 4, 1, "http://jr:0000");
-INSERT INTO request_archives (request_id, create_request, job_chain) VALUES ("454ae2f98a05cv16sdwt", '{"some":"param"}', '{"requestId":"454ae2f98a05cv16sdwt","jobs":{"590s":{"id":"590s","type":"fake","bytes":null,"state":3,"args":null,"data":null,"retry":0},"9sa1":{"id":"9sa1","type":"fake","bytes":null,"state":4,"args":null,"data":null,"retry":0},"di12":{"id":"di12","type":"fake","bytes":null,"state":3,"args":null,"data":null,"retry":0},"g012":{"id":"g012","type":"fake","bytes":null,"state":1,"args":null,"data":null,"retry":0},"ldfi":{"id":"ldfi","type":"fake","bytes":null,"state":2,"args":null,"data":null,"retry":0},"pzi8":{"id":"pzi8","type":"fake","bytes":null,"state":1,"args":null,"data":null,"retry":0}},"adjacencyList":{"590s":["g012"],"9sa1":["pzi8"],"di12":["ldfi","590s","9sa1"],"g012":["pzi8"],"ldfi":["pzi8"]},"state":2}');
-INSERT INTO job_log (request_id, job_id, try, type, state) VALUES ("454ae2f98a05cv16sdwt", "di12", 0, "fake", 3),
-                                                                  ("454ae2f98a05cv16sdwt", "590s", 0, "fake", 4), -- this job failed on its first try
-                                                                  ("454ae2f98a05cv16sdwt", "590s", 1, "fake", 3), -- succeeded on its second
-                                                                  ("454ae2f98a05cv16sdwt", "g012", 0, "fake", 1),
-                                                                  ("454ae2f98a05cv16sdwt", "9sa1", 0, "fake", 4), -- failed on its only try
-                                                                  ("454ae2f98a05cv16sdwt", "pzi8", 0, "fake", 1);
+INSERT INTO request_archives (request_id, create_request, args, job_chain) VALUES ("454ae2f98a05cv16sdwt", '{"some":"param"}', '', '{"requestId":"454ae2f98a05cv16sdwt","jobs":{"590s":{"id":"590s","type":"fake","bytes":null,"state":3,"args":null,"data":null,"retry":0},"9sa1":{"id":"9sa1","type":"fake","bytes":null,"state":4,"args":null,"data":null,"retry":0},"di12":{"id":"di12","type":"fake","bytes":null,"state":3,"args":null,"data":null,"retry":0},"g012":{"id":"g012","type":"fake","bytes":null,"state":1,"args":null,"data":null,"retry":0},"ldfi":{"id":"ldfi","type":"fake","bytes":null,"state":2,"args":null,"data":null,"retry":0},"pzi8":{"id":"pzi8","type":"fake","bytes":null,"state":1,"args":null,"data":null,"retry":0}},"adjacencyList":{"590s":["g012"],"9sa1":["pzi8"],"di12":["ldfi","590s","9sa1"],"g012":["pzi8"],"ldfi":["pzi8"]},"state":2}');
+INSERT INTO job_log (request_id, job_id, name, try, type, state) VALUES ("454ae2f98a05cv16sdwt", "di12", "", 0, "fake", 3),
+                                                                        ("454ae2f98a05cv16sdwt", "590s", "", 0, "fake", 4), -- this job failed on its first try
+                                                                        ("454ae2f98a05cv16sdwt", "590s", "", 1, "fake", 3), -- succeeded on its second
+                                                                        ("454ae2f98a05cv16sdwt", "g012", "", 0, "fake", 1),
+                                                                        ("454ae2f98a05cv16sdwt", "9sa1", "", 0, "fake", 4), -- failed on its only try
+                                                                        ("454ae2f98a05cv16sdwt", "pzi8", "", 0, "fake", 1);
 
 -- a completed request
 INSERT INTO requests (request_id, type, created_at, state) VALUES ("93ec156e204ety45sgf0", 'something-else', '2017-09-13 02:00:00', 3);
 
 -- a suspended request + job chain + suspended job chain
 INSERT INTO requests (request_id, type, created_at, state, started_at) VALUES ("suspended___________", 'do-another-thing', '2017-09-13 03:00:00', 7, '2017-09-13 03:01:00');
-INSERT INTO request_archives (request_id, create_request, job_chain) VALUES ("suspended___________", '{"some":"param"}', '{"requestId":"suspended___________","jobs":{"hw48":{"id":"hw48","type":"test","bytes":null,"state":1,"args":null,"data":null,"retry":5,"sequenceId":"hw48","sequenceRetry":1}},"adjacencyList":null,"state":1}');
+INSERT INTO request_archives (request_id, create_request, args, job_chain) VALUES ("suspended___________", '{"some":"param"}', '', '{"requestId":"suspended___________","jobs":{"hw48":{"id":"hw48","type":"test","bytes":null,"state":1,"args":null,"data":null,"retry":5,"sequenceId":"hw48","sequenceRetry":1}},"adjacencyList":null,"state":1}');
 INSERT INTO suspended_job_chains (request_id, suspended_job_chain) VALUES ("suspended___________", '{"requestId":"suspended___________","jobChain":{"requestId":"suspended___________","jobs":{"hw48":{"id":"hw48","type":"test","bytes":null,"state":6,"args":null,"data":null,"retry":5,"sequenceId":"hw48","sequenceRetry":1}},"adjacencyList":null,"state":7},"totalJobTries":{"hw48":5},"latestRunJobTries":{"hw48":2},"sequenceTries":{"hw48":1}}');
 
 -- a suspended request + claimed SJC that hasn't been updated recently

--- a/request-manager/test/data/retry-job-live-status.sql
+++ b/request-manager/test/data/retry-job-live-status.sql
@@ -3,8 +3,8 @@
 INSERT INTO requests (request_id, type, user, created_at, started_at, total_jobs, finished_jobs, state, jr_url)
   VALUES ("aaabbbcccdddeeefff00", "req-name", "finch", "2019-03-04 00:00:00", "2019-03-04 00:00:00", 3, 0, 2, "http://localhost"); -- proto.STATE_RUNNING=2
 
-INSERT INTO request_archives (request_id, create_request, job_chain)
-  VALUES ("aaabbbcccdddeeefff00", '{"arg1":"arg1val"}', '{"requestId":"aaabbbcccdddeeefff00","jobs":{"0001":{"id":"0001","type":"job1Type","args":null,"retry":1,"retryWait":"3s"},"0002":{"id":"0002","type":"job2Type","args":null},"0003":{"id":"0003","type":"job3Type","args":null}}}');
+INSERT INTO request_archives (request_id, create_request, args, job_chain)
+  VALUES ("aaabbbcccdddeeefff00", '{"arg1":"arg1val"}', '', '{"requestId":"aaabbbcccdddeeefff00","jobs":{"0001":{"id":"0001","type":"job1Type","args":null,"retry":1,"retryWait":"3s"},"0002":{"id":"0002","type":"job2Type","args":null},"0003":{"id":"0003","type":"job3Type","args":null}}}');
 
 -- In test, mock JR is still running this job on 2nd try, but 1st try failed so we have a JLE like:
 INSERT INTO job_log (request_id, job_id, name, `type`, try, state, started_at, finished_at, error, `exit`)


### PR DESCRIPTION
The request manager DB schema defines tables having some columns with no
default values. Inserting records into these tables without defining
values for those columns results in an error when MySQL is run in strict
SQL mode. For instance:

    ERROR 1364 (HY000) ... Field 'args' doesn't have a default value

This commit adjusts the insert statements in request manager's test data
to include all required columns and give them empty values, specifically
"request_archives.args" and "job_log.name". This allows unit tests to
pass while in strict SQL mode.