### PR TITLE
Add Support for Jobs Ending in "UNKNOWN" State

### DIFF
--- a/job-runner/chain/chain.go
+++ b/job-runner/chain/chain.go
@@ -124,7 +124,7 @@ func (c *Chain) IsDoneRunning() (done bool, complete bool) {
 			}
 			// This job is pending but not runnable which means a previous job
 			// failed.
-		case proto.STATE_FAIL:
+		case proto.STATE_FAIL, proto.STATE_UNKNOWN:
 			// If sequence can retry, then chain isn't done or complete,
 			if c.canRetrySequence(job.Id) {
 				return false, false
@@ -150,7 +150,7 @@ func (c *Chain) FailedJobs() uint {
 	defer c.jobsMux.RUnlock()
 	n := uint(0)
 	for _, job := range c.jobChain.Jobs {
-		if job.State == proto.STATE_FAIL {
+		if job.State == proto.STATE_FAIL || job.State == proto.STATE_UNKNOWN {
 			n++
 		}
 	}

--- a/job-runner/chain/reaper.go
+++ b/job-runner/chain/reaper.go
@@ -354,6 +354,14 @@ func (r *SuspendedChainReaper) Reap(job proto.Job) {
 		if r.chain.CanRetrySequence(job.Id) {
 			r.prepareSequenceRetry(job)
 		}
+	case proto.STATE_UNKNOWN:
+		jLogger.Warn("job state unknown")
+		// Treat an unknown state as a failure for the purpose of retrying.
+		// Prepare for sequence retry but don't actually start the retry.
+		// This gets the chain ready to be resumed later on.
+		if r.chain.CanRetrySequence(job.Id) {
+			r.prepareSequenceRetry(job)
+		}
 	case proto.STATE_COMPLETE:
 		jLogger.Infof("job completed")
 		r.chain.IncrementFinishedJobs(1)

--- a/job-runner/chain/reaper_test.go
+++ b/job-runner/chain/reaper_test.go
@@ -191,6 +191,66 @@ func TestRunningReapFail(t *testing.T) {
 	}
 }
 
+// runningChainReaper.Reap on an "unknown" state job (no sequence retry)
+func TestRunningReapUnknown(t *testing.T) {
+	// Job Chain:
+	// 1 - 2 - 3
+	//  \_ 4
+	// Testing when job 2 fails
+
+	reqId := "test_running_reap_fail"
+	factory := defaultFactory(reqId)
+	jc := &proto.JobChain{
+		RequestId: reqId,
+		Jobs:      testutil.InitJobs(4),
+		AdjacencyList: map[string][]string{
+			"job1": {"job2", "job4"},
+			"job2": {"job3"},
+		},
+	}
+	c := chain.NewChain(jc, make(map[string]uint), make(map[string]uint), make(map[string]uint))
+	factory.Chain = c
+
+	// Normally runJobChan is unbuffered. Here we use a buffer so Reap
+	// doesn't block on sending to the chan (though we don't expect any values
+	// to be sent after a job fails).
+	runJobChan := make(chan proto.Job, 5)
+	factory.RunJobChan = runJobChan
+	reaper := factory.MakeRunning()
+
+	c.IncrementSequenceTries("job1", 1)
+	c.SetJobState("job1", proto.STATE_COMPLETE)
+	c.SetJobState("job2", proto.STATE_RUNNING)
+
+	// Job 2 has just returned an unknown state.
+	job := proto.Job{
+		Id:    "job2",
+		State: proto.STATE_UNKNOWN,
+		Data: map[string]interface{}{
+			"key1": "val1",
+		},
+	}
+	reaper.(*chain.RunningChainReaper).Reap(job)
+
+	// no jobs should be sent to runJobChan
+	select {
+	case gotJob := <-runJobChan:
+		t.Errorf("got job %s from runJobChan, expected no job", gotJob.Id)
+	default:
+	}
+
+	// job2's state should have been set in the chain
+	gotState := c.JobState("job2")
+	if gotState != proto.STATE_UNKNOWN {
+		t.Errorf("job2 state in chain = %d, expected state = %d", gotState, proto.STATE_UNKNOWN)
+	}
+
+	// Job data should not have been copied to job3
+	if len(jc.Jobs["job3"].Data) != 0 {
+		t.Errorf("job3 has job data - no data should have been copied from job2")
+	}
+}
+
 // runningChainReaper.Reap on a failed job whose sequence can be retried
 func TestRunningReapFailRetry(t *testing.T) {
 	// Job Chain:
@@ -229,6 +289,86 @@ func TestRunningReapFailRetry(t *testing.T) {
 	job := proto.Job{
 		Id:    "job2",
 		State: proto.STATE_FAIL,
+		Data: map[string]interface{}{
+			"key1": "val1",
+		},
+		SequenceId: "job1",
+	}
+	reaper.(*chain.RunningChainReaper).Reap(job)
+
+	// job1 should be (re)sent to runJobChan
+	select {
+	case gotJob := <-runJobChan:
+		if gotJob.Id != "job1" {
+			t.Errorf("got job %s from runJobChan, expected job %s", gotJob.Id, "job1")
+		}
+	default:
+		t.Errorf("no job sent to runJobChan - expected to get job1")
+	}
+
+	// no other jobs should be sent to runJobChan
+	select {
+	case <-runJobChan:
+		t.Errorf("more than one job sent to runJobChan - expected only job1")
+	default:
+	}
+
+	// all job states should have been set back to PENDING
+	for id := range jc.Jobs {
+		gotState := c.JobState(id)
+		if gotState != proto.STATE_PENDING {
+			t.Errorf("%s state in chain = %d, expected state = %d", id, gotState, proto.STATE_PENDING)
+		}
+	}
+
+	// Sequence try count is _not_ incremented yet. That happens in traverser.runJobs
+	// when the sequence start job is ran, which is the true indicator that a sequence
+	// has been tried. Between reaper doing sequece retry prep and then, the chain
+	// could be stopped, etc. and the seq never actually retried.
+	tryCount := c.SequenceTries(job.Id)
+	if tryCount != 1 {
+		t.Errorf("got sequence try count %d, expected 1", tryCount)
+	}
+}
+
+// runningChainReaper.Reap on a "unknown" state job whose sequence can be retried
+func TestRunningReapUnknownRetry(t *testing.T) {
+	// Job Chain:
+	// 1 - 2 - 3
+	//  \_ 4
+	// Testing when job 2 fails (+ sequence is retryable)
+
+	reqId := "test_running_reap_fail_retry"
+	factory := defaultFactory(reqId)
+	jc := &proto.JobChain{
+		RequestId: reqId,
+		Jobs:      testutil.InitJobsWithSequenceRetry(4, 1),
+		AdjacencyList: map[string][]string{
+			"job1": {"job2", "job4"},
+			"job2": {"job3"},
+		},
+		FinishedJobs: 2,
+	}
+	c := chain.NewChain(jc, make(map[string]uint), make(map[string]uint), make(map[string]uint))
+	factory.Chain = c
+
+	// Normally runJobChan is unbuffered. Here we use a buffer so Reap
+	// doesn't block on sending to the chan.
+	runJobChan := make(chan proto.Job, 5)
+	factory.RunJobChan = runJobChan
+	reaper := factory.MakeRunning()
+
+	c.IncrementSequenceTries("job1", 1)
+	c.IncrementJobTries("job1", 1)
+	c.IncrementJobTries("job4", 1)
+	c.SetJobState("job1", proto.STATE_COMPLETE)
+	c.SetJobState("job4", proto.STATE_COMPLETE)
+	c.SetJobState("job2", proto.STATE_RUNNING)
+
+	// Job 2 has just failed.
+	job := proto.Job{
+		Id:    "job2",
+		State: proto.STATE_UNKNOWN,
 		Data: map[string]interface{}{
 			"key1": "val1",
 		},
@@ -366,6 +506,130 @@ func TestRunningReaper(t *testing.T) {
 		"job3": proto.STATE_COMPLETE,
 		"job4": proto.STATE_COMPLETE,
 		"job5": proto.STATE_FAIL,
+	}
+	expectedJobData := map[string]interface{}{
+		"key1": "val1",
+	}
+	for _, job := range jc.Jobs {
+		if job.State != expectedStates[job.Id] {
+			t.Errorf("got state %s for job %s, expected state %s", proto.StateName[job.State], job.Id, proto.StateName[expectedStates[job.Id]])
+		}
+		if diff := deep.Equal(job.Data, expectedJobData); diff != nil {
+			t.Errorf("job data for job %s not as expected: %s", job.Id, diff)
+		}
+	}
+
+	// check that finalize was sent with correct state
+	if !sent {
+		t.Errorf("final chain state not sent to RM client")
+		return
+	}
+
+	if receivedState != proto.STATE_FAIL {
+		t.Errorf("chain state %s sent to RM client, expected state %s", proto.StateName[receivedState], proto.StateName[proto.STATE_FAIL])
+	}
+
+	finishedJobs := c.FinishedJobs()
+	if finishedJobs != 4 {
+		t.Errorf("got finished jobs %d, expected 4", finishedJobs)
+	}
+}
+
+// test runningChainReaper.Run on a new chain (faking the runJobs loop)
+func TestRunningReaperUnknownState(t *testing.T) {
+	// Job Chain:
+	//      2 - 5
+	//     / \
+	// -> 1   4
+	//     \ /
+	//      3
+
+	reqId := "test_running_reaper"
+	jc := &proto.JobChain{
+		RequestId: reqId,
+		Jobs:      testutil.InitJobsWithSequenceRetry(5, 1),
+		AdjacencyList: map[string][]string{
+			"job1": {"job2", "job3"},
+			"job2": {"job4", "job5"},
+			"job3": {"job4"},
+		},
+		FinishedJobs: 0,
+	}
+	job1 := jc.Jobs["job1"]
+	job1.Data = map[string]interface{}{
+		"key1": "val1",
+	}
+	jc.Jobs["job1"] = job1
+	c := chain.NewChain(jc, make(map[string]uint), make(map[string]uint), make(map[string]uint))
+
+	sent := false
+	var receivedState byte
+	rmc := &mock.RMClient{
+		FinishRequestFunc: func(fr proto.FinishRequest) error {
+			sent = true
+			receivedState = fr.State
+			return nil
+		},
+	}
+
+	// Normally these chans are unbuffered, but give them buffers here to make
+	// testing easier (don't need to worry about sends blocking).
+	runJobChan := make(chan proto.Job, 10)
+	doneJobChan := make(chan proto.Job, 10)
+
+	factory := &chain.ChainReaperFactory{
+		Chain:        c,
+		RMClient:     rmc,
+		Logger:       log.WithFields(log.Fields{"requestId": reqId}),
+		RMCTries:     5,
+		RMCRetryWait: 50 * time.Millisecond,
+		DoneJobChan:  doneJobChan,
+		RunJobChan:   runJobChan,
+		RunnerRepo:   runner.NewRepo(),
+	}
+	reaper := factory.MakeRunning()
+
+	go func() {
+		reaper.Run()
+		close(runJobChan)
+	}()
+
+	// Complete job 1 so 2 and 3 are enqueued
+	c.IncrementSequenceTries("job1", 1)
+	c.SetJobState("job1", proto.STATE_RUNNING)
+	job1 = jc.Jobs["job1"]
+	job1.State = proto.STATE_COMPLETE
+	doneJobChan <- job1
+
+	// Fail job 2 or 3 (whichever we recv first) so we trigger a seq retry
+	// which should re-run jobs 1, 2, and 3
+	job := <-runJobChan
+	job.State = proto.STATE_UNKNOWN
+	doneJobChan <- job
+
+	// Complete all jobs except fail job 5
+	for job := range runJobChan {
+		if job.Id == "job5" {
+			job.State = proto.STATE_UNKNOWN
+			doneJobChan <- job
+			continue
+		}
+		// Seq try incremented in runJobs not reaper, so we need to simulate
+		// this here else the chain retries infinitely
+		if job.Id == "job1" {
+			c.IncrementSequenceTries("job1", 1)
+		}
+		job.State = proto.STATE_COMPLETE
+		doneJobChan <- job
+	}
+
+	// check state and job data of every job
+	expectedStates := map[string]byte{
+		"job1": proto.STATE_COMPLETE,
+		"job2": proto.STATE_COMPLETE,
+		"job3": proto.STATE_COMPLETE,
+		"job4": proto.STATE_COMPLETE,
+		"job5": proto.STATE_UNKNOWN,
 	}
 	expectedJobData := map[string]interface{}{
 		"key1": "val1",
@@ -860,6 +1124,62 @@ func TestSuspendedReapFail(t *testing.T) {
 	}
 }
 
+// test suspendedChainReaper.Reap on a "unknown" state job (retryable)
+func TestSuspendedReapUnknown(t *testing.T) {
+	// Job Chain:
+	//       2 - 5
+	//     /  \
+	// -> 1    4
+	//     \  /
+	//      3
+	// Testing when Job 2 fails
+
+	reqId := "test_suspended_reap_fail"
+	factory := defaultFactory(reqId)
+	jc := &proto.JobChain{
+		RequestId: reqId,
+		Jobs:      testutil.InitJobsWithSequenceRetry(5, 1),
+		AdjacencyList: map[string][]string{
+			"job1": {"job2", "job3"},
+			"job2": {"job4", "job5"},
+			"job3": {"job4"},
+		},
+		FinishedJobs: 1, // job1
+	}
+	c := chain.NewChain(jc, make(map[string]uint), make(map[string]uint), make(map[string]uint))
+	factory.Chain = c
+
+	reaper := factory.MakeSuspended()
+
+	c.IncrementSequenceTries("job1", 1)
+	c.SetJobState("job1", proto.STATE_COMPLETE)
+	c.SetJobState("job2", proto.STATE_RUNNING)
+
+	// Job 2 has just completed
+	job := proto.Job{
+		Id:    "job2",
+		State: proto.STATE_UNKNOWN,
+		Data: map[string]interface{}{
+			"key1": "val1",
+		},
+	}
+	reaper.(*chain.SuspendedChainReaper).Reap(job)
+
+	// all job states should have been set back to PENDING
+	for id := range jc.Jobs {
+		gotState := c.JobState(id)
+		if gotState != proto.STATE_PENDING {
+			t.Errorf("%s state in chain = %d, expected state = %d", id, gotState, proto.STATE_PENDING)
+		}
+	}
+
+	// sequence tries in chain should not have been incremented
+	tryCount := c.SequenceTries(job.Id)
+	if tryCount != 1 {
+		t.Errorf("got sequence try count %d, expected %d", tryCount, 1)
+	}
+}
+
 // test suspendedChainReaper.Reap on a stopped job (this is the normal case)
 func TestSuspendedReapStopped(t *testing.T) {
 	// Job Chain:
@@ -1034,6 +1354,252 @@ func TestSuspendedReaper(t *testing.T) {
 	}
 	if diff := deep.Equal(receivedSJC, expectedSJC); diff != nil {
 		t.Errorf("received SJC != expected SJC: %s", diff)
+	}
+}
+
+// test suspendedChainReaper.Run
+func TestSuspendedReaperUnknownState(t *testing.T) {
+	// Job Chain:
+	//          6
+	//         /
+	//       2 - 5
+	//     /  \
+	// -> 1    4
+	//     \  /
+	//      3
+	// jobs 3, 5, 6 running
+
+	reqId := "test_suspended_reaper"
+	jc := &proto.JobChain{
+		RequestId: reqId,
+		Jobs:      testutil.InitJobs(6),
+		AdjacencyList: map[string][]string{
+			"job1": {"job2", "job3"},
+			"job2": {"job4", "job5", "job6"},
+			"job3": {"job4"},
+		},
+	}
+
+	// Make job6 a separate sequence
+	job := jc.Jobs["job6"]
+	job.SequenceId = "job6"
+	job.SequenceRetry = 1
+	jc.Jobs["job6"] = job
+	c := chain.NewChain(jc, make(map[string]uint), make(map[string]uint), make(map[string]uint))
+
+	sentState := false
+	sentSJC := false
+	var receivedSJC proto.SuspendedJobChain
+	rmc := &mock.RMClient{
+		FinishRequestFunc: func(fr proto.FinishRequest) error {
+			sentState = true
+			return nil
+		},
+		SuspendRequestFunc: func(reqId string, sjc proto.SuspendedJobChain) error {
+			sentSJC = true
+			receivedSJC = sjc
+			return nil
+		},
+	}
+
+	doneJobChan := make(chan proto.Job)
+	runnerRepo := runner.NewRepo()
+	factory := &chain.ChainReaperFactory{
+		Chain:        c,
+		RMClient:     rmc,
+		Logger:       log.WithFields(log.Fields{"requestId": reqId}),
+		RMCTries:     5,
+		RMCRetryWait: 50 * time.Millisecond,
+		DoneJobChan:  doneJobChan,
+		RunJobChan:   make(chan proto.Job),
+		RunnerRepo:   runnerRepo,
+	}
+	reaper := factory.MakeSuspended()
+
+	c.IncrementFinishedJobs(2)
+	c.IncrementSequenceTries("job1", 1)
+	c.IncrementSequenceTries("job6", 1)
+	c.SetJobState("job1", proto.STATE_COMPLETE)
+	c.SetJobState("job2", proto.STATE_COMPLETE)
+	c.SetJobState("job3", proto.STATE_RUNNING)
+	c.SetJobState("job5", proto.STATE_RUNNING)
+	c.SetJobState("job6", proto.STATE_RUNNING)
+	runnerRepo.Set("job3", &mock.Runner{})
+	runnerRepo.Set("job5", &mock.Runner{})
+	runnerRepo.Set("job6", &mock.Runner{})
+
+	job3 := jc.Jobs["job3"]
+	job3.State = proto.STATE_STOPPED
+	job5 := jc.Jobs["job5"]
+	job5.State = proto.STATE_COMPLETE
+	job6 := jc.Jobs["job6"]
+	job6.State = proto.STATE_UNKNOWN
+
+	doneChan := make(chan struct{})
+	go func() {
+		reaper.Run()
+		close(doneChan)
+	}()
+
+	doneJobChan <- job3
+	runnerRepo.Remove("job3")
+
+	doneJobChan <- job5
+	runnerRepo.Remove("job5")
+
+	doneJobChan <- job6
+	runnerRepo.Remove("job6")
+
+	<-doneChan // wait for reaper to finish
+
+	if c.JobState("job3") != proto.STATE_STOPPED {
+		t.Errorf("got state %s for job %s, expected state %s", proto.StateName[c.JobState("job3")], "job3", proto.StateName[proto.STATE_STOPPED])
+	}
+	if c.JobState("job5") != proto.STATE_COMPLETE {
+		t.Errorf("got state %s for job %s, expected state %s", proto.StateName[c.JobState("job5")], "job5", proto.StateName[proto.STATE_COMPLETE])
+	}
+	if c.JobState("job6") != proto.STATE_PENDING {
+		t.Errorf("got state %s for job %s, expected state %s", proto.StateName[c.JobState("job6")], "job6", proto.StateName[proto.STATE_PENDING])
+	}
+
+	if sentState {
+		t.Errorf("chain state sent to RM client, expected only SJC to be sent")
+	}
+
+	if !sentSJC {
+		t.Fatal("SJC not sent to RM client")
+	}
+
+	expectedSJC := proto.SuspendedJobChain{
+		RequestId:     reqId,
+		JobChain:      jc,
+		TotalJobTries: map[string]uint{},
+		LatestRunJobTries: map[string]uint{
+			"job6": 0,
+		},
+		SequenceTries: map[string]uint{
+			"job1": 1,
+			"job6": 1,
+		},
+	}
+	if diff := deep.Equal(receivedSJC, expectedSJC); diff != nil {
+		t.Errorf("received SJC != expected SJC: %s", diff)
+	}
+}
+
+// Make sure that UKNOWN state will cause a failure due to no more retries
+func TestSuspendedReaperUnknownStateNoRetries(t *testing.T) {
+	// Job Chain:
+	//          6
+	//         /
+	//       2 - 5
+	//     /  \
+	// -> 1    4
+	//     \  /
+	//      3
+	// jobs 3, 5, 6 running
+
+	reqId := "test_suspended_reaper"
+	jc := &proto.JobChain{
+		RequestId: reqId,
+		Jobs:      testutil.InitJobs(6),
+		AdjacencyList: map[string][]string{
+			"job1": {"job2", "job3"},
+			"job2": {"job4", "job5", "job6"},
+			"job3": {"job4"},
+		},
+	}
+
+	// Make job6 a separate sequence
+	job := jc.Jobs["job6"]
+	job.SequenceId = "job6"
+	job.SequenceRetry = 0
+	jc.Jobs["job6"] = job
+	c := chain.NewChain(jc, make(map[string]uint), make(map[string]uint), make(map[string]uint))
+
+	sentState := false
+	var receivedState byte
+	rmc := &mock.RMClient{
+		FinishRequestFunc: func(fr proto.FinishRequest) error {
+			sentState = true
+			receivedState = fr.State
+			return nil
+		},
+	}
+
+	doneJobChan := make(chan proto.Job)
+	runnerRepo := runner.NewRepo()
+	factory := &chain.ChainReaperFactory{
+		Chain:        c,
+		RMClient:     rmc,
+		Logger:       log.WithFields(log.Fields{"requestId": reqId}),
+		RMCTries:     5,
+		RMCRetryWait: 50 * time.Millisecond,
+		DoneJobChan:  doneJobChan,
+		RunJobChan:   make(chan proto.Job),
+		RunnerRepo:   runnerRepo,
+	}
+	reaper := factory.MakeSuspended()
+
+	c.IncrementFinishedJobs(2)
+	c.IncrementSequenceTries("job1", 1)
+	c.IncrementSequenceTries("job6", 1)
+	c.SetJobState("job1", proto.STATE_COMPLETE)
+	c.SetJobState("job2", proto.STATE_COMPLETE)
+	c.SetJobState("job3", proto.STATE_RUNNING)
+	c.SetJobState("job5", proto.STATE_RUNNING)
+	c.SetJobState("job6", proto.STATE_UNKNOWN)
+	runnerRepo.Set("job3", &mock.Runner{})
+	runnerRepo.Set("job5", &mock.Runner{})
+	runnerRepo.Set("job6", &mock.Runner{})
+
+	job3 := jc.Jobs["job3"]
+	job3.State = proto.STATE_STOPPED
+	job5 := jc.Jobs["job5"]
+	job5.State = proto.STATE_COMPLETE
+	job6 := jc.Jobs["job6"]
+	job6.State = proto.STATE_UNKNOWN
+
+	doneChan := make(chan struct{})
+	go func() {
+		reaper.Run()
+		close(doneChan)
+	}()
+
+	doneJobChan <- job3
+	runnerRepo.Remove("job3")
+
+	doneJobChan <- job5
+	runnerRepo.Remove("job5")
+
+	doneJobChan <- job6
+	runnerRepo.Remove("job6")
+
+	<-doneChan // wait for reaper to finish
+
+	if c.JobState("job3") != proto.STATE_STOPPED {
+		t.Errorf("got state %s for job %s, expected state %s", proto.StateName[c.JobState("job3")], "job3", proto.StateName[proto.STATE_STOPPED])
+	}
+	if c.JobState("job5") != proto.STATE_COMPLETE {
+		t.Errorf("got state %s for job %s, expected state %s", proto.StateName[c.JobState("job5")], "job5", proto.StateName[proto.STATE_COMPLETE])
+	}
+	if c.JobState("job6") != proto.STATE_UNKNOWN {
+		t.Errorf("got state %s for job %s, expected state %s", proto.StateName[c.JobState("job6")], "job6", proto.StateName[proto.STATE_UNKNOWN])
+	}
+
+	// check that finalize was sent with correct state
+	if !sentState {
+		t.Errorf("final chain state not sent to RM client")
+		return
+	}
+
+	if receivedState != proto.STATE_FAIL {
+		t.Errorf("chain state %s sent to RM client, expected state %s", proto.StateName[receivedState], proto.StateName[proto.STATE_FAIL])
+	}
+
+	finishedJobs := c.FinishedJobs()
+	if finishedJobs != 3 {
+		t.Errorf("got finished jobs %d, expected 3", finishedJobs)
 	}
 }
 


### PR DESCRIPTION
Adding support for jobs that end in an "UKNOWN" state. Jobs in unknown states are treated as a failure state instead of causing a panic. If possible the sequence should be retried as with a normal failure and if that is not possible or it is not able to be retried then the request should end in failure and not a panic.