### PR TITLE
Add Options to output from "start"

### DIFF
--- a/spinc/app/app.go
+++ b/spinc/app/app.go
@@ -30,10 +30,11 @@ type Context struct {
 	Factories Factories // for integration with other code
 
 	// Set automatically in spinc.Run()
-	Options  config.Options // command line options (--addr, etc.)
-	Command  config.Command // command and args, if any ("start <request>", etc.)
-	RMClient rm.Client      // Request Manager client
-	Nargs    int            // number of positional args including command
+	Options     config.Options // command line options (--addr, etc.)
+	Command     config.Command // command and args, if any ("start <request>", etc.)
+	UserOptions config.Options // command line options explictly set by the user
+	RMClient    rm.Client      // Request Manager client
+	Nargs       int            // number of positional args including command
 }
 
 type Command interface {

--- a/spinc/spinc.go
+++ b/spinc/spinc.go
@@ -28,6 +28,9 @@ func Run(ctx app.Context) error {
 	// So first we must apply config files, then do cmd line parsing which
 	// will apply env vars and cmd line options.
 
+	// Parse the cmd line to get the options explicitly set by the user
+	userOptions := config.ParseUserOptions(config.UserOptions{})
+
 	// Parse cmd line to get --config files
 	cmdLine := config.ParseCommandLine(config.Options{})
 
@@ -84,6 +87,10 @@ func Run(ctx app.Context) error {
 
 	ctx.Options = o
 	ctx.Command = c
+
+	// Update the user options after the hooks are processed
+	ctx.UserOptions = userOptions.ToOptions()
+
 	if o.Debug {
 		app.Debug("command: %#v\n", c)
 		app.Debug("options: %#v\n", o)


### PR DESCRIPTION
Updated the full command output by `start` to include relevant options that can affect the way the command runs. This includes: env, addr, and config. Adding basic escaping in the event the options include spaces.