### PR TITLE
Fix panic on --help or --version

### DIFF
--- a/spinc/config/config.go
+++ b/spinc/config/config.go
@@ -78,11 +78,14 @@ func ParseUserOptions(def UserOptions) UserOptions {
 		fmt.Printf("arg.NewParser: %s", err)
 		os.Exit(1)
 	}
+
 	if err := p.Parse(os.Args[1:]); err != nil {
 		switch err {
 		case arg.ErrHelp:
+			c.Help = new(bool)
 			*c.Help = true
 		case arg.ErrVersion:
+			c.Version = new(bool)
 			*c.Version = true
 		default:
 			fmt.Printf("Error parsing command line: %s\n", err)

--- a/spinc/spinc_test.go
+++ b/spinc/spinc_test.go
@@ -24,3 +24,17 @@ func TestArgsNoCommand(t *testing.T) {
 		t.Errorf("got error '%v', expected ErrHelp", err)
 	}
 }
+
+func TestArgsHelpCommand(t *testing.T) {
+	ctx := app.Context{
+		In:        os.Stdin,
+		Out:       &bytes.Buffer{},
+		Hooks:     app.Hooks{},
+		Factories: app.Factories{},
+	}
+	os.Args = []string{"spinc", "--help"}
+	err := spinc.Run(ctx)
+	if err != app.ErrHelp {
+		t.Errorf("got error '%v', expected ErrHelp", err)
+	}
+}


### PR DESCRIPTION
Allocate memory for `UserConfig` pointers before assigning values to them, as the setting of the "help" and "version" options is non-standard. Added unit test to validate this case.